### PR TITLE
[FE] ReviewLayoutLoading 컴포넌트 구현

### DIFF
--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -16,8 +16,7 @@ function PageRoutes() {
         <Route element={<ReviewLayout />}>
           <Route index element={<MainPage />} />
 
-          <Route path={PAGE_LIST.REVIEW_FORM}>
-            <Route index element={<ReviewFormPage />} />
+          <Route path={PAGE_LIST.REVIEW_FORM} element={<ReviewFormPage />}>
             <Route path={':reviewFormCode'} element={<ReviewFormPage />} />
           </Route>
 

--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -16,7 +16,8 @@ function PageRoutes() {
         <Route element={<ReviewLayout />}>
           <Route index element={<MainPage />} />
 
-          <Route path={PAGE_LIST.REVIEW_FORM} element={<ReviewFormPage />}>
+          <Route path={PAGE_LIST.REVIEW_FORM}>
+            <Route index element={<ReviewFormPage />} />
             <Route path={':reviewFormCode'} element={<ReviewFormPage />} />
           </Route>
 

--- a/frontend/src/service/review/layout/ReviewLayout/ReviewLayoutLoading.tsx
+++ b/frontend/src/service/review/layout/ReviewLayout/ReviewLayoutLoading.tsx
@@ -1,0 +1,24 @@
+import cn from 'classnames';
+
+import { Logo } from 'common/components';
+
+import Skeleton from 'common/components/Skeleton';
+
+import styles from './styles.module.scss';
+
+const ReviewLayoutLoading = () => {
+  return (
+    <>
+      <div className={cn('flex-container column', styles.loadingContainer)}>
+        <Logo />
+        <Skeleton line={3} />
+      </div>
+
+      <div className={cn('flex-container column', styles.loadingContainer)}>
+        <Skeleton line={4} />
+      </div>
+    </>
+  );
+};
+
+export default ReviewLayoutLoading;

--- a/frontend/src/service/review/layout/ReviewLayout/index.tsx
+++ b/frontend/src/service/review/layout/ReviewLayout/index.tsx
@@ -1,30 +1,15 @@
 import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
 
-import { Logo } from 'common/components';
-
-import Skeleton from 'common/components/Skeleton';
-
 import styles from './styles.module.scss';
+
+import ReviewLayoutLoading from './ReviewLayoutLoading';
 
 function ReviewLayout() {
   return (
     <div className={styles.background}>
       <div className={styles.container}>
-        <Suspense
-          fallback={
-            <>
-              <div className="flex-container column" style={{ gap: '2rem' }}>
-                <Logo />
-                <Skeleton line={3} />
-              </div>
-
-              <div className="flex-container column" style={{ gap: '2rem' }}>
-                <Skeleton line={4} />
-              </div>
-            </>
-          }
-        >
+        <Suspense fallback={<ReviewLayoutLoading />}>
           <Outlet />
         </Suspense>
       </div>

--- a/frontend/src/service/review/layout/ReviewLayout/styles.module.scss
+++ b/frontend/src/service/review/layout/ReviewLayout/styles.module.scss
@@ -57,3 +57,7 @@
     padding: 3rem;
   }
 }
+
+.loading-container {
+  gap: 2rem;
+}


### PR DESCRIPTION
- Suspense fallback으로 사용될 레이아웃 자체 로딩 컴포넌트 구현

### 제안: 레이아웃 자체를 대상으로 fallback 하는 컴포넌트를 만들어도 괜찮을 것 같습니다.

만약에 나중에 레이아웃 안에서 컴포넌트로 분리돼서 각각의 컴포넌트에서 각기 다른 API 요청이 생긴다면 그 때는 해당 레이아웃이 있어도 내부에 중첩해서 한 번 더 suspense를 하면 해당 suspense 가 적용될 것입니다.

> 렌더링을 시도할 컴포넌트가 남아있지 않으면, 컴포넌트 트리 상에서 존재하는 것 중 가장 가까운 Suspense, 혹은 ErrorBoundary의 Fallback UI를 찾습니다.
[참고링크](https://maxkim-j.github.io/posts/suspense-argibraic-effect)