### PR TITLE
Github OAuth를 활용한 로그인 및 인증/인가 영역 추가

### DIFF
--- a/frontend/env/development.env
+++ b/frontend/env/development.env
@@ -1,1 +1,2 @@
 API_URL=https://backend.reviewduck.takealook.kr
+GITHUB_OAUTH_CLIENT_KEY=174f27a19dc8e1e8c6ba

--- a/frontend/env/production.env
+++ b/frontend/env/production.env
@@ -1,1 +1,2 @@
 API_URL=https://backend.reviewduck.takealook.kr
+GITHUB_OAUTH_CLIENT_KEY=174f27a19dc8e1e8c6ba

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, Suspense } from 'react';
 import { QueryClientProvider, QueryClient } from 'react-query';
 
 import PageRoutes from 'PageRoutes';
@@ -23,11 +23,14 @@ function ContextWrapper({ children }: { children: ReactNode }) {
 }
 
 function App() {
+  // TODO: 전역 페이지 로딩 화면 구현하기, 페이지 단위로 lazy 로드 처리
   return (
     <ContextWrapper>
-      <ErrorBoundary>
-        <PageRoutes />
-      </ErrorBoundary>
+      <Suspense>
+        <ErrorBoundary>
+          <PageRoutes />
+        </ErrorBoundary>
+      </Suspense>
     </ContextWrapper>
   );
 }

--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -1,6 +1,12 @@
+import { Suspense } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
-import { PAGE_LIST } from 'service/@shared/constants';
+import useAuth from 'service/@shared/hooks/useAuth';
+
+import RequireAuth from 'service/@shared/components/RequireAuth';
+
+import { ACCESS_PERMISSION, PAGE_LIST } from 'service/@shared/constants';
+import Authorize from 'service/@shared/pages/Authorize';
 import CommunityLayout from 'service/community/layout/CommunityLayout';
 import ReviewLayout from 'service/review/layout/ReviewLayout';
 import MainPage from 'service/review/pages/MainPage';
@@ -11,22 +17,26 @@ import ReviewOverviewPage from 'service/review/pages/ReviewOverviewPage';
 import ReviewPage from 'service/review/pages/ReviewPage';
 
 function PageRoutes() {
+  const { isLogin } = useAuth();
+
   return (
     <BrowserRouter>
       <Routes>
         <Route element={<ReviewLayout />}>
           <Route index element={<MainPage />} />
 
-          <Route path={PAGE_LIST.REVIEW_FORM}>
-            <Route index element={<ReviewFormPage />} />
-            <Route path={':reviewFormCode'} element={<ReviewFormPage />} />
-          </Route>
+          <Route element={<RequireAuth />}>
+            <Route path={PAGE_LIST.REVIEW_FORM}>
+              <Route index element={<ReviewFormPage />} />
+              <Route path={':reviewFormCode'} element={<ReviewFormPage />} />
+            </Route>
 
-          <Route>
-            <Route path={PAGE_LIST.REVIEW_JOIN} element={<ReviewJoinPage />} />
-            <Route path={PAGE_LIST.REVIEW}>
-              <Route index element={<ReviewPage />} />
-              <Route path=":reviewFormCode" element={<ReviewPage />} />
+            <Route>
+              <Route path={PAGE_LIST.REVIEW_JOIN} element={<ReviewJoinPage />} />
+              <Route path={PAGE_LIST.REVIEW}>
+                <Route index element={<ReviewPage />} />
+                <Route path=":reviewFormCode" element={<ReviewPage />} />
+              </Route>
             </Route>
           </Route>
         </Route>
@@ -38,6 +48,10 @@ function PageRoutes() {
         <Route path={PAGE_LIST.REVIEW_OVERVIEW}>
           <Route index element={<ReviewOverviewPage />} />
           <Route path=":reviewFormCode" element={<ReviewOverviewPage />} />
+        </Route>
+
+        <Route element={<RequireAuth permission={ACCESS_PERMISSION.NON_LOGIN} />}>
+          <Route path={PAGE_LIST.AUTHORIZE} element={<Authorize />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -50,7 +50,7 @@ function PageRoutes() {
           <Route path=":reviewFormCode" element={<ReviewOverviewPage />} />
         </Route>
 
-        <Route element={<RequireAuth permission={ACCESS_PERMISSION.NON_LOGIN} />}>
+        <Route element={<RequireAuth permission={ACCESS_PERMISSION.LOGOUT_USER} />}>
           <Route path={PAGE_LIST.AUTHORIZE} element={<Authorize />} />
         </Route>
       </Routes>

--- a/frontend/src/service/@shared/api/axiosInstance.ts
+++ b/frontend/src/service/@shared/api/axiosInstance.ts
@@ -3,6 +3,7 @@ import axios from 'axios';
 const axiosInstance = axios.create({
   baseURL: process.env.API_URL,
   timeout: 3000,
+  withCredentials: true,
 });
 
 axiosInstance.interceptors.response.use(

--- a/frontend/src/service/@shared/api/index.ts
+++ b/frontend/src/service/@shared/api/index.ts
@@ -1,0 +1,28 @@
+import { CreateRefreshTokenRequest, CreateRefreshResponse, UserProfileResponse } from '../types';
+
+import axiosInstance from './axiosInstance';
+
+const createRefreshToken = async (
+  query: CreateRefreshTokenRequest,
+): Promise<CreateRefreshResponse> => {
+  const { data } = await axiosInstance.post('/api/login', query);
+
+  return data;
+};
+
+const getRefreshedAccessToken = async (): Promise<CreateRefreshResponse> => {
+  // TODO: API 명세 GET으로 바뀔 예정입니다.
+  const { data } = await axiosInstance.post('/api/login/refresh');
+
+  return data;
+};
+
+const getProfile = async (): Promise<UserProfileResponse> => {
+  const { data } = await axiosInstance.post('/api/members/me');
+
+  return data;
+};
+
+const userAPI = { createRefreshToken, getRefreshedAccessToken, getProfile };
+
+export { userAPI };

--- a/frontend/src/service/@shared/components/RequireAuth/index.tsx
+++ b/frontend/src/service/@shared/components/RequireAuth/index.tsx
@@ -3,14 +3,17 @@ import { Navigate, Outlet } from 'react-router-dom';
 
 import useAuth from 'service/@shared/hooks/useAuth';
 
-import { PAGE_LIST } from 'service/@shared/constants';
+import { ACCESS_PERMISSION, PAGE_LIST } from 'service/@shared/constants';
 
 interface Props {
   permission?: boolean;
   isDeniedPageEnabled?: boolean;
 }
 
-function RequireAuth({ permission = true, isDeniedPageEnabled = false }: Props) {
+function RequireAuth({
+  permission = ACCESS_PERMISSION.LOGIN_USER,
+  isDeniedPageEnabled = false,
+}: Props) {
   // TODO: 유저 프로필 확인 API 구현 시 getUserProfileQuery로 변경 필요
   const { getAccessTokenQuery } = useAuth();
 

--- a/frontend/src/service/@shared/components/RequireAuth/index.tsx
+++ b/frontend/src/service/@shared/components/RequireAuth/index.tsx
@@ -1,0 +1,32 @@
+import { useLayoutEffect } from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+import useAuth from 'service/@shared/hooks/useAuth';
+
+import { PAGE_LIST } from 'service/@shared/constants';
+
+interface Props {
+  permission?: boolean;
+  isDeniedPageEnabled?: boolean;
+}
+
+function RequireAuth({ permission = true, isDeniedPageEnabled = false }: Props) {
+  // TODO: 유저 프로필 확인 API 구현 시 getUserProfileQuery로 변경 필요
+  const { getAccessTokenQuery } = useAuth();
+
+  useLayoutEffect(() => {
+    getAccessTokenQuery.refetch();
+  }, []);
+
+  const isLogin = getAccessTokenQuery.isSuccess;
+
+  if (isLogin !== permission) {
+    // TODO: isDeniedPageEnabled 값에 따라 로그인 유도 페이지로 이동 처리
+    alert(isLogin ? '이미 로그인하였습니다.' : '권한이 없습니다. 로그인을 해주세요.');
+    return <Navigate to={PAGE_LIST.HOME} />;
+  }
+
+  return <Outlet />;
+}
+
+export default RequireAuth;

--- a/frontend/src/service/@shared/constants/index.ts
+++ b/frontend/src/service/@shared/constants/index.ts
@@ -23,6 +23,12 @@ const QUERY_KEY = {
   },
 };
 
+const GITHUB_OAUTH_ERROR = {
+  APPLICATION_SUSPENDED: 'application_suspended',
+  ACCESS_DENIED: 'access_denied',
+  REDIRECT_URI_MISMATCH: 'redirect_uri_mismatch',
+};
+
 const ACCESS_PERMISSION = {
   NON_LOGIN: false,
 };
@@ -36,6 +42,7 @@ const ACCESS_VALID_TIME = 60;
 export {
   PAGE_LIST,
   QUERY_KEY,
+  GITHUB_OAUTH_ERROR,
   ACCESS_PERMISSION,
   ACCESS_TOKEN_EXPIRE_TIME,
   ACCESS_TOKEN_REFRESH_TIME,

--- a/frontend/src/service/@shared/constants/index.ts
+++ b/frontend/src/service/@shared/constants/index.ts
@@ -30,7 +30,8 @@ const GITHUB_OAUTH_ERROR = {
 };
 
 const ACCESS_PERMISSION = {
-  NON_LOGIN: false,
+  LOGOUT_USER: false,
+  LOGIN_USER: true,
 };
 
 const ACCESS_TOKEN_EXPIRE_TIME = 60 * 10 * 1000;

--- a/frontend/src/service/@shared/constants/index.ts
+++ b/frontend/src/service/@shared/constants/index.ts
@@ -4,11 +4,40 @@ const PAGE_LIST = {
   REVIEW: '/review',
   REVIEW_JOIN: '/review/join',
   REVIEW_OVERVIEW: '/overview',
+  AUTHORIZE: '/authorize',
 };
 
 const QUERY_KEY = {
-  GET_REVIEWS: 'getReviews',
-  GET_REVIEW_FORM: 'getReviewForm',
+  DATA: {
+    USER: 'user',
+
+    REVIEW: 'review',
+    REVIEW_FORM: 'review-form',
+  },
+  API: {
+    GET_ACCESS_TOKEN: 'getRefreshedAccessToken',
+    GET_USER_PROFILE: 'getUserProfile',
+
+    GET_REVIEWS: 'getReviews',
+    GET_REVIEW_FORM: 'getReviewForm',
+  },
 };
 
-export { PAGE_LIST, QUERY_KEY };
+const ACCESS_PERMISSION = {
+  NON_LOGIN: false,
+};
+
+const ACCESS_TOKEN_EXPIRE_TIME = 60 * 10 * 1000;
+
+const ACCESS_TOKEN_REFRESH_TIME = ACCESS_TOKEN_EXPIRE_TIME - 60 * 2 * 1000;
+
+const ACCESS_VALID_TIME = 60;
+
+export {
+  PAGE_LIST,
+  QUERY_KEY,
+  ACCESS_PERMISSION,
+  ACCESS_TOKEN_EXPIRE_TIME,
+  ACCESS_TOKEN_REFRESH_TIME,
+  ACCESS_VALID_TIME,
+};

--- a/frontend/src/service/@shared/hooks/queries/user/useCreateRefreshToken.ts
+++ b/frontend/src/service/@shared/hooks/queries/user/useCreateRefreshToken.ts
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from 'react-query';
+
+import { CreateRefreshResponse } from 'service/@shared/types';
+import { UseCustomMutationOptions } from 'service/review/types';
+
+import { userAPI } from 'service/@shared/api';
+import { QUERY_KEY } from 'service/@shared/constants';
+
+function useCreateRefreshToken(mutationOptions?: UseCustomMutationOptions<CreateRefreshResponse>) {
+  const queryClient = useQueryClient();
+
+  return useMutation(userAPI.createRefreshToken, {
+    onSettled: () => {
+      queryClient.refetchQueries([QUERY_KEY.DATA.USER, QUERY_KEY.API.GET_ACCESS_TOKEN]);
+    },
+    ...mutationOptions,
+  });
+}
+
+export default useCreateRefreshToken;

--- a/frontend/src/service/@shared/hooks/queries/user/useGetAccessToken.ts
+++ b/frontend/src/service/@shared/hooks/queries/user/useGetAccessToken.ts
@@ -1,0 +1,28 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import { CreateRefreshResponse } from 'service/@shared/types';
+import { ErrorResponse } from 'service/review/types';
+
+import { userAPI } from 'service/@shared/api';
+import {
+  ACCESS_TOKEN_EXPIRE_TIME,
+  ACCESS_TOKEN_REFRESH_TIME,
+  QUERY_KEY,
+} from 'service/@shared/constants';
+
+function useGetAccessToken(queryOptions?: UseQueryOptions<CreateRefreshResponse, ErrorResponse>) {
+  return useQuery<CreateRefreshResponse, ErrorResponse>(
+    [QUERY_KEY.DATA.USER, QUERY_KEY.API.GET_ACCESS_TOKEN],
+    () => userAPI.getRefreshedAccessToken(),
+    {
+      suspense: true,
+      useErrorBoundary: false,
+      staleTime: ACCESS_TOKEN_EXPIRE_TIME,
+      refetchInterval: ACCESS_TOKEN_REFRESH_TIME,
+      refetchIntervalInBackground: true,
+      ...queryOptions,
+    },
+  );
+}
+
+export default useGetAccessToken;

--- a/frontend/src/service/@shared/hooks/queries/user/useGetUserProfie.ts
+++ b/frontend/src/service/@shared/hooks/queries/user/useGetUserProfie.ts
@@ -1,0 +1,22 @@
+import { useQuery, UseQueryOptions } from 'react-query';
+
+import { UserProfileResponse } from 'service/@shared/types';
+import { ErrorResponse } from 'service/review/types';
+
+import { userAPI } from 'service/@shared/api';
+import { ACCESS_VALID_TIME, QUERY_KEY } from 'service/@shared/constants';
+
+function useGetUserProfile(queryOptions?: UseQueryOptions<UserProfileResponse, ErrorResponse>) {
+  return useQuery<UserProfileResponse, ErrorResponse>(
+    [QUERY_KEY.DATA.USER, QUERY_KEY.API.GET_USER_PROFILE],
+    () => userAPI.getProfile(),
+    {
+      suspense: true,
+      useErrorBoundary: false,
+      staleTime: ACCESS_VALID_TIME,
+      ...queryOptions,
+    },
+  );
+}
+
+export default useGetUserProfile;

--- a/frontend/src/service/@shared/hooks/useAuth.ts
+++ b/frontend/src/service/@shared/hooks/useAuth.ts
@@ -1,0 +1,33 @@
+import useGetAccessToken from 'service/@shared/hooks/queries/user/useGetAccessToken';
+
+import { axiosInstanceUtils } from '../utils';
+
+import useCreateRefreshToken from './queries/user/useCreateRefreshToken';
+import useGetUserProfile from './queries/user/useGetUserProfie';
+
+function useAuth() {
+  const createRefreshToken = useCreateRefreshToken({
+    onSuccess: ({ accessToken }) => {
+      axiosInstanceUtils.setHeader('Authorization', `Bearer ${accessToken}`);
+    },
+  });
+
+  const getAccessTokenQuery = useGetAccessToken({
+    onSuccess: ({ accessToken }) => {
+      axiosInstanceUtils.setHeader('Authorization', `Bearer ${accessToken}`);
+    },
+    onError: () => {
+      axiosInstanceUtils.removeHeader('Authorization');
+    },
+  });
+
+  const getUserProfileQuery = useGetUserProfile({
+    enabled: false,
+  });
+
+  const isLogin = getAccessTokenQuery.isSuccess; // TODO: getUserProfileQuery
+
+  return { createRefreshToken, getAccessTokenQuery, getUserProfileQuery, isLogin };
+}
+
+export default useAuth;

--- a/frontend/src/service/@shared/hooks/useAuth.ts
+++ b/frontend/src/service/@shared/hooks/useAuth.ts
@@ -6,11 +6,7 @@ import useCreateRefreshToken from './queries/user/useCreateRefreshToken';
 import useGetUserProfile from './queries/user/useGetUserProfie';
 
 function useAuth() {
-  const createRefreshToken = useCreateRefreshToken({
-    onSuccess: ({ accessToken }) => {
-      axiosInstanceUtils.setHeader('Authorization', `Bearer ${accessToken}`);
-    },
-  });
+  const createRefreshToken = useCreateRefreshToken();
 
   const getAccessTokenQuery = useGetAccessToken({
     onSuccess: ({ accessToken }) => {

--- a/frontend/src/service/@shared/pages/Authorize/index.tsx
+++ b/frontend/src/service/@shared/pages/Authorize/index.tsx
@@ -1,0 +1,55 @@
+import { useLayoutEffect } from 'react';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
+
+import useAuth from 'service/@shared/hooks/useAuth';
+
+import { GITHUB_OAUTH_ERROR, PAGE_LIST } from 'service/@shared/constants';
+
+function Authorize() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const { createRefreshToken } = useAuth();
+
+  const { code = '', error = '' } = Object.fromEntries(searchParams.entries());
+
+  switch (error) {
+    case GITHUB_OAUTH_ERROR.APPLICATION_SUSPENDED:
+      alert('Github OAuth 정책을 확인하여주세요.');
+      break;
+
+    case GITHUB_OAUTH_ERROR.ACCESS_DENIED:
+      alert('Github 소셜 로그인 시도를 취소하셨습니다.');
+      break;
+
+    case GITHUB_OAUTH_ERROR.REDIRECT_URI_MISMATCH:
+      alert('잘못된 URL입니다.');
+      break;
+
+    // no default.
+  }
+
+  useLayoutEffect(() => {
+    if (!code && !error) {
+      alert('잘못된 접근입니다.');
+      return;
+    }
+
+    createRefreshToken.mutate(
+      { code },
+      {
+        onSettled: () => {
+          navigate(PAGE_LIST.HOME);
+        },
+        onError: ({ message }) => {
+          alert(message);
+        },
+      },
+    );
+  }, []);
+
+  // TODO: 로그인 진행 화면 디자인
+  return <Navigate to={PAGE_LIST.HOME} />;
+}
+
+export default Authorize;

--- a/frontend/src/service/@shared/types/index.ts
+++ b/frontend/src/service/@shared/types/index.ts
@@ -1,0 +1,13 @@
+export interface CreateRefreshTokenRequest {
+  code: string;
+}
+
+export interface CreateRefreshResponse {
+  accessToken: string;
+}
+
+export interface UserProfileResponse {
+  socialId: string;
+  nickname: string;
+  profileUrl: string;
+}

--- a/frontend/src/service/@shared/utils/axiosInstance/index.ts
+++ b/frontend/src/service/@shared/utils/axiosInstance/index.ts
@@ -1,2 +1,0 @@
-export { default as axiosInstance } from './createInstance';
-export { setAccessTokenHeader } from './instanceUtils';

--- a/frontend/src/service/@shared/utils/axiosInstance/instanceUtils.ts
+++ b/frontend/src/service/@shared/utils/axiosInstance/instanceUtils.ts
@@ -1,9 +1,0 @@
-import { AxiosInstance } from 'axios';
-
-export const setAccessTokenHeader = (enable: boolean, axiosInstance: AxiosInstance) => {
-  const setHeader = axiosInstance.defaults.headers;
-
-  enable
-    ? (setHeader.common['Authorization'] = 'Bearer {액세스토큰이 입력될 곳}')
-    : delete setHeader.common['Authorization'];
-};

--- a/frontend/src/service/@shared/utils/axiosInstanceUtils.ts
+++ b/frontend/src/service/@shared/utils/axiosInstanceUtils.ts
@@ -1,0 +1,19 @@
+import axiosInstance from 'service/@shared/api/axiosInstance';
+
+const getHeader = (key: string) => {
+  return axiosInstance.defaults.headers.common[key];
+};
+
+const setHeader = (key: string, value: string) => {
+  axiosInstance.defaults.headers.common[key] = value;
+};
+
+const removeHeader = (key: string) => {
+  if (axiosInstance.defaults.headers.common[key]) return;
+
+  delete axiosInstance.defaults.headers.common[key];
+};
+
+const axiosInstanceUtils = { getHeader, setHeader, removeHeader };
+
+export default axiosInstanceUtils;

--- a/frontend/src/service/@shared/utils/index.ts
+++ b/frontend/src/service/@shared/utils/index.ts
@@ -1,3 +1,2 @@
 export { default as setFormFocus } from './setFormFocus';
-
-export { axiosInstance, setAccessTokenHeader } from './axiosInstance';
+export { default as axiosInstanceUtils } from './axiosInstanceUtils';

--- a/frontend/src/service/community/layout/CommunityLayout/index.tsx
+++ b/frontend/src/service/community/layout/CommunityLayout/index.tsx
@@ -32,9 +32,13 @@ function CommunityLayout() {
               <span>회고 시작하기</span>
             </Button>
 
-            <Text className={styles.loginText} weight="lighter">
-              LOGIN
-            </Text>
+            <a
+              href={`https://github.com/login/oauth/authorize?client_id=${process.env.GITHUB_OAUTH_CLIENT_KEY}`}
+            >
+              <Text className={styles.loginText} weight="lighter">
+                LOGIN
+              </Text>
+            </a>
             {/*  <div className={styles.profile}></div> */}
           </div>
         </nav>

--- a/frontend/src/service/review/api/index.ts
+++ b/frontend/src/service/review/api/index.ts
@@ -7,7 +7,7 @@ import {
   UpdateReviewFormResponse,
 } from '../types';
 
-import { axiosInstance } from 'service/@shared/utils';
+import axiosInstance from 'service/@shared/api/axiosInstance';
 
 const getForm = async (reviewFormCode = ''): Promise<GetReviewFormResponse> => {
   const { data } = await axiosInstance.get(`/api/review-forms/${reviewFormCode}`);

--- a/frontend/src/service/review/hooks/queries/useCreateReviewAnswer.ts
+++ b/frontend/src/service/review/hooks/queries/useCreateReviewAnswer.ts
@@ -1,16 +1,23 @@
 import { useMutation, useQueryClient } from 'react-query';
 
-import { UseCustomMutationOptions } from 'service/review/types';
+import { CreateReviewAnswer, UseCustomMutationOptions } from 'service/review/types';
 
 import { QUERY_KEY } from 'service/@shared/constants';
 import reviewAPI from 'service/review/api';
 
-function useCreateReviewAnswer(reviewFormCode: string, mutationOptions?: UseCustomMutationOptions) {
+function useCreateReviewAnswer(
+  reviewFormCode: string,
+  mutationOptions?: UseCustomMutationOptions<CreateReviewAnswer>,
+) {
   const queryClient = useQueryClient();
 
   return useMutation(reviewAPI.submitAnswer, {
     onSuccess: () => {
-      queryClient.invalidateQueries([QUERY_KEY.GET_REVIEWS, { reviewFormCode }]);
+      queryClient.invalidateQueries([
+        QUERY_KEY.DATA.REVIEW,
+        QUERY_KEY.API.GET_REVIEWS,
+        { reviewFormCode },
+      ]);
     },
     ...mutationOptions,
   });

--- a/frontend/src/service/review/hooks/queries/useCreateReviewForm.ts
+++ b/frontend/src/service/review/hooks/queries/useCreateReviewForm.ts
@@ -1,10 +1,10 @@
 import { useMutation } from 'react-query';
 
-import { UseCustomMutationOptions } from 'service/review/types';
+import { UpdateReviewFormResponse, UseCustomMutationOptions } from 'service/review/types';
 
 import reviewAPI from 'service/review/api';
 
-function useCreateReviewForm(mutationOptions?: UseCustomMutationOptions) {
+function useCreateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateReviewFormResponse>) {
   return useMutation(reviewAPI.createForm, {
     ...mutationOptions,
   });

--- a/frontend/src/service/review/hooks/queries/useGetReviewForm.ts
+++ b/frontend/src/service/review/hooks/queries/useGetReviewForm.ts
@@ -10,7 +10,7 @@ function useGetReviewForm(
   queryOptions?: UseQueryOptions<GetReviewFormResponse, ErrorResponse>,
 ) {
   return useQuery<GetReviewFormResponse, ErrorResponse>(
-    [QUERY_KEY.GET_REVIEW_FORM, { reviewFormCode }],
+    [QUERY_KEY.DATA.REVIEW_FORM, QUERY_KEY.API.GET_REVIEW_FORM, { reviewFormCode }],
     () => reviewAPI.getForm(reviewFormCode),
     {
       suspense: true,

--- a/frontend/src/service/review/hooks/queries/useGetReviews.ts
+++ b/frontend/src/service/review/hooks/queries/useGetReviews.ts
@@ -10,7 +10,7 @@ function useGetReviews(
   queryOptions?: UseQueryOptions<GetReviewsResponse, ErrorResponse>,
 ) {
   return useQuery<GetReviewsResponse, ErrorResponse>(
-    [QUERY_KEY.GET_REVIEWS, { reviewFormCode }],
+    [QUERY_KEY.DATA.REVIEW, QUERY_KEY.API.GET_REVIEWS, { reviewFormCode }],
     () => reviewAPI.getReviews(reviewFormCode),
     {
       suspense: true,

--- a/frontend/src/service/review/hooks/queries/useUpdateReviewForm.ts
+++ b/frontend/src/service/review/hooks/queries/useUpdateReviewForm.ts
@@ -1,17 +1,20 @@
 import { useMutation, useQueryClient } from 'react-query';
 
-import { UseCustomMutationOptions } from 'service/review/types';
+import { UpdateReviewFormResponse, UseCustomMutationOptions } from 'service/review/types';
 
 import { QUERY_KEY } from 'service/@shared/constants';
 import reviewAPI from 'service/review/api';
 
-function useUpdateReviewForm(reviewFormCode: string, mutationOptions?: UseCustomMutationOptions) {
+function useUpdateReviewForm(
+  reviewFormCode: string,
+  mutationOptions?: UseCustomMutationOptions<UpdateReviewFormResponse>,
+) {
   const queryClient = useQueryClient();
 
   return useMutation(reviewAPI.updateForm, {
     onSuccess: () => {
-      queryClient.invalidateQueries([QUERY_KEY.GET_REVIEW_FORM, { reviewFormCode }]);
-      queryClient.invalidateQueries([QUERY_KEY.GET_REVIEWS, { reviewFormCode }]);
+      queryClient.invalidateQueries([QUERY_KEY.API.GET_REVIEW_FORM, { reviewFormCode }]);
+      queryClient.invalidateQueries([QUERY_KEY.API.GET_REVIEWS, { reviewFormCode }]);
     },
     ...mutationOptions,
   });

--- a/frontend/src/service/review/types/index.ts
+++ b/frontend/src/service/review/types/index.ts
@@ -55,4 +55,8 @@ export interface SubmitAnswerRequest {
   nickname: string;
 }
 
-export type UseCustomMutationOptions = UseMutationOptions<unknown, ErrorResponse, unknown>;
+export type UseCustomMutationOptions<TData = unknown> = UseMutationOptions<
+  TData,
+  ErrorResponse,
+  unknown
+>;


### PR DESCRIPTION
# 추가된 기능 목록 🚀
* Github OAuth를 활용한 로그인 시도
* Router 영역에서 인증/인가 처리
* 액세스 토큰 만료 전 자동 갱신 처리
* 브라우저가 종료된 이후, 다시 접속할 시 액세스 토큰 등록 처리


# 사전 설명 ✏️
### 🍪 Refresh Token & Access Token
`Refresh Token`은 백엔드 측에서 브라우저에 쿠키로 저장합니다.
하지만 쿠키 옵션 중 `httpOnly` 옵션을 주어, 프론트엔드의 코드 레벨에서는 접근할 수 없습니다.

`Access Token`은 프론트엔드 측에서 실질적으로 관리하는 토큰입니다.

하지만, 이전 미션에서 진행한 일반적인 방식(스토리지, 쿠키)과 다르게
비공개 변수를 통해 `Access Token`을 저장하고 있으며, 유효 기간도 10분으로 매우 짧습니다.

* `Refresh Token`은 `Access Token`을 발급/갱신 하는데 사용합니다.
* `Access Token`은 사용자의 정보를 확인하는데 사용합니다. 

이 부분에 대한 좀 더 자세한 설명은 제가 이전에 작성한 Prolog 글 확인 부탁드립니다.
: https://prolog.techcourse.co.kr/studylogs/2272

---

### ✅ 이번 로그인 개발 팀에서 해결하고 싶었던 점
프론트엔드의 코드 레벨에서 토큰을 처리하는 행위는
스토리지든, 쿠키 저장 방식은 모두 `XSS`, `CSRF` 공격에 취약합니다!

그리하여 백엔드 팀과 협업을 통해 아래와 같이 문제를 해결했습니다.

1. 백엔드 팀에서는 `Refresh Token`에 `httpOnly`, `Secure`, `SemeSite` 옵션을 주어 프론트엔드의 코드 레벨에서 해당 토큰에 접근할 수 없게하여 `Refresh Token`에 대한 CSRF, XSS 공격을 차단하였고 
2. 프론트엔드 팀에서는 `Refresh Token`에 접근할 수 없지만 쿠키에 저장되고, **백엔드 API와 동일한 도메인 범위에서 https 통신 시**에는 `Refresh Token`의 쿠키 값이 함께 전송되기에
사용자의 브라우저가 종료되어도 `Access Token`을 API 요청만으로 바로 발급 받을 수 있게 됩니다.
3. 그 결과 `Access Token`을 스토리지, 쿠키에 저장하는 것이 아닌, 비공개 변수 상에 저장하게 하여 프론트엔드에서도 `CSRF`, `XSS` 공격을 원천적으로 차단할 수 있게 됩니다.

---

# 구조 설명
## 로그인 플로우
1. 로그인 버튼 클릭을 클릭할 시, Github OAuth Client Key를 담은 Github 로그인 페이지로 이동합니다.
2. GIthub에서 로그인 혹은 로그인 취소를 할 시 `/authorize` 페이지로 이동하여, 이곳에서 로그인 성공/실패에 따른 에러 핸들링을 진행합니다.
3. Github 로그인 성공 시, 인증 코드를 API에 담아 백엔드 서버에 전달하여, Refresh Token"만" 발급 받습니다.
4. React Query의 queryClient를 활용하여, useGetAccessToken에 refetch를 요청합니다
5. useGetAccessToken의 useQuery의 요청이 성공할 시 받아온 Access Token을 Axios Instance의 Header에만 저장합니다.

## 재접속 시 플로우
1. 사용자가 브라우저를 종료한 이후 페이지에 다시 접속할 시, Refresh Token의 유/무와 관계 없이 API를 통해 Access Token을 발급 요청을 합니다.
(코드 레벨에서 Refresh Token을 확인할 수 없기에, 검증은 백엔드 측에서 진행)
2. Access Token에 발급에 성공할 시 로그인과 동일한 위치에 저장합니다.
3. 실패할 시 8분 후 다시 발급을 시도하거나, 로그인 시 즉시 발동됩니다.


## 체크 포인트
* Access Token은 토근 만료 2분 전에 갱신되며, 로그인/비로그인 여부에 관계 없이 요청합니다.
이유 : 사용자가 다른 탭에서 로그인을 시도하였다면?
* 유저 정보는 서버 상태라 생각하여, React Query를 통해 관리합니다.
* refetch, query 무효화 등의 요청은 Query Hook에서 진행하되, 관심사 분리를 위해 Axios Instance Header 조작은 Query Hook에서 처리하지 않고, `useAuth` 커스텀 훅에서 처리합니다.


## 컴포넌트 설명
### RequireAuth
리액트 라우터에서 페이지 접근 권한을 일괄적으로 제어하기 위해 제작한 컴포넌트입니다.
아래와 같이 권한 별 접근 범위를 제어할 수 있습니다.

```jsx
<Route element={<RequireAuth permission={ACCESS_PERMISSION.LOGOUT_USER} />}>
  <Route path="/url" element="<>로그인한 유저만 접근할 수 있는 페이지</>"/>
</Route>

<Route element={<RequireAuth permission={ACCESS_PERMISSION.LOGIN_USER} />}>
  <Route path="/url" element="<>로그아웃한 유저만 접근할 수 있는 페이지</>"/>
</Route>

```



추가적으로 궁금하신 부분, 개선 필요한 부분은 리뷰 남겨주십쇼!