### PR TITLE
오버뷰, 회고리뷰 페이지 접근 에러시 적절하게 리다이렉트 및 각종 버그 수정

### DIFF
--- a/frontend/src/service/@shared/components/QuestionContent/styles.module.scss
+++ b/frontend/src/service/@shared/components/QuestionContent/styles.module.scss
@@ -18,7 +18,8 @@
     }
 
     & > .answer-content {
-      white-space: pre;
+      white-space: pre-wrap;
+      word-break: break-word;
       font-size: 1rem;
       color: $THEME_COLOR_THEME_TEXT_800;
       line-height: 140%;

--- a/frontend/src/service/review/pages/MainPage/index.tsx
+++ b/frontend/src/service/review/pages/MainPage/index.tsx
@@ -25,7 +25,7 @@ function MainPage() {
           간편하게 모아 볼 수 있습니다
         </Text>
         <div className="button-container horizontal">
-          <Link to={PAGE_LIST.REVIEW_FORM} state={{ redirect: `${PAGE_LIST.REVIEW_OVERVIEW}` }}>
+          <Link to={PAGE_LIST.REVIEW_FORM}>
             <Button type="button" filled>
               <Icon type="outlined" code="maps_ugc" />
               <span>회고 생성</span>

--- a/frontend/src/service/review/pages/ReviewFormPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewFormPage/index.tsx
@@ -40,9 +40,7 @@ function CreateReviewFormPage() {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const state = location.state as RedirectState;
-
-  const redirectUrl = (state && state.redirect) || '';
+  const { redirect = '' } = (location.state as RedirectState) || {};
 
   const { reviewFormMutation, getReviewFormQuery, initReviewFormData } =
     useReviewFormQueries(reviewFormCode);
@@ -120,10 +118,7 @@ function CreateReviewFormPage() {
       { reviewTitle, reviewFormCode, questions: removeListKey },
       {
         onSuccess: ({ reviewFormCode }) => {
-          navigate(
-            `${redirectUrl}${redirectUrl !== PAGE_LIST.MY_PAGE ? `/${reviewFormCode}` : ''}`,
-            { replace: true },
-          );
+          navigate(redirect || `${PAGE_LIST.REVIEW_OVERVIEW}/${reviewFormCode}`, { replace: true });
           addSnackbar({
             title: isEditMode ? '회고가 수정되었습니다.' : '회고가 생성되었습니다.',
             description: '회고 참여코드를 공유하여, 회고를 시작할 수 있습니다.',

--- a/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSheetView.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSheetView.tsx
@@ -25,7 +25,9 @@ function ReviewSheetView({ reviewFormCode }: Record<'reviewFormCode', string>) {
       <tbody>
         {reviews.map(({ answers, participant, reviewId }: Review) => {
           const answersTable = answers.map((answer: Answer) => (
-            <td key={reviewId}>{answer.answerValue}</td>
+            <td className={styles.answer} key={reviewId}>
+              {answer.answerValue}
+            </td>
           ));
 
           return (

--- a/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSideMenu.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSideMenu.tsx
@@ -148,7 +148,7 @@ function ReviewSideMenu({ reviewFormCode }: Record<'reviewFormCode', string>) {
                     {review.participant.nickname}
                   </Text>
                   <Text className={styles.update} size={12}>{`${getElapsedTimeText(
-                    reviewForm?.updatedAt,
+                    review.updatedAt,
                   )} 업데이트함`}</Text>
                 </div>
               </div>

--- a/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSideMenu.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSideMenu.tsx
@@ -86,7 +86,6 @@ function ReviewSideMenu({ reviewFormCode }: Record<'reviewFormCode', string>) {
           to={`${PAGE_LIST.REVIEW}/${reviewFormCode}${
             getMyReviewId() >= 0 ? `/${getMyReviewId()}` : ''
           }`}
-          state={{ redirect: `${PAGE_LIST.REVIEW_OVERVIEW}` }}
         >
           <Button className={styles.joinButton} theme="outlined">
             <Icon code="group_add" />이 회고에 참여하기
@@ -116,10 +115,7 @@ function ReviewSideMenu({ reviewFormCode }: Record<'reviewFormCode', string>) {
             </Text>
 
             <div className={styles.buttonContainer}>
-              <Link
-                to={`${PAGE_LIST.REVIEW_FORM}/${reviewFormCode}`}
-                state={{ redirect: `${PAGE_LIST.REVIEW_OVERVIEW}` }}
-              >
+              <Link to={`${PAGE_LIST.REVIEW_FORM}/${reviewFormCode}`}>
                 <Button size="small">
                   <Icon code="edit_note" />
                   질문 수정

--- a/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSideMenu.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/containers/ReviewSideMenu.tsx
@@ -141,7 +141,7 @@ function ReviewSideMenu({ reviewFormCode }: Record<'reviewFormCode', string>) {
         </Text>
         <div className={styles.participantListContainer}>
           {reviews.map((review) => (
-            <a className={styles.hashLink} href={`#${review.reviewId}`} key={review.reviewId}>
+            <a href={`#${review.reviewId}`} key={review.reviewId}>
               <div className={styles.listItemContainer} role="button" tabIndex={0}>
                 <div
                   className={styles.profile}

--- a/frontend/src/service/review/pages/ReviewOverviewPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/index.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import cn from 'classnames';
 
@@ -18,6 +18,7 @@ import { PAGE_LIST } from 'service/@shared/constants';
 
 function ReviewOverviewPage() {
   const { reviewFormCode = '' } = useParams();
+  const naviagte = useNavigate();
 
   const [isSheetEnabled, setSheetEnabled] = useState(false);
 
@@ -32,6 +33,7 @@ function ReviewOverviewPage() {
   useEffect(() => {
     if (isError) {
       alert(error?.message);
+      naviagte(-1);
     }
   }, [isError, error]);
 

--- a/frontend/src/service/review/pages/ReviewOverviewPage/styles.module.scss
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/styles.module.scss
@@ -302,6 +302,11 @@
     line-height: 160%;
   }
 
+  .answer {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
   & tbody tr:hover {
     background-color: $THEME_COLOR_THEME_BACKGROUND_200;
   }

--- a/frontend/src/service/review/pages/ReviewOverviewPage/styles.module.scss
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/styles.module.scss
@@ -148,6 +148,12 @@
   flex-direction: row;
   gap: 0.5rem;
   overflow: scroll hidden;
+
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }
 
 .post-container {

--- a/frontend/src/service/review/pages/ReviewPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewPage/index.tsx
@@ -29,7 +29,7 @@ function SubmitReviewPage() {
   const { addSnackbar } = useSnackbar();
 
   const location = useLocation();
-  const { redirect = '' } = location.state as RedirectState;
+  const { redirect = '' } = (location.state as RedirectState) || {};
 
   const { getReviewFormQuery, reviewForm, review, createMutation, updateMutation } =
     useReviewQueries(reviewFormCode, reviewId);

--- a/frontend/src/service/review/pages/ReviewPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewPage/index.tsx
@@ -58,6 +58,9 @@ function SubmitReviewPage() {
   const isSubmitDisabled =
     answeredCount !== questions.length || createMutation.isLoading || updateMutation.isLoading;
 
+  const getRedirectUrl = () =>
+    `${redirectUrl}${redirectUrl !== PAGE_LIST.MY_PAGE ? `/${reviewFormCode}` : ''}`;
+
   const onSubmitReviewForm = (event: React.FormEvent) => {
     event.preventDefault();
 
@@ -66,9 +69,6 @@ function SubmitReviewPage() {
       answerId,
       answerValue,
     }));
-
-    const getRedirectUrl = () =>
-      `${redirectUrl}${redirectUrl !== PAGE_LIST.MY_PAGE ? `/${reviewFormCode}` : ''}`;
 
     if (reviewId) {
       updateMutation.mutate(
@@ -125,7 +125,7 @@ function SubmitReviewPage() {
 
   if (getReviewFormQuery.isError) {
     alert('찾을 수 없는 참여 코드입니다.');
-    return <Navigate to={'/'} replace={true} />;
+    return <Navigate to={getRedirectUrl()} replace={true} />;
   }
 
   return (


### PR DESCRIPTION
### 리다이렉트 규격 변경
특별히 redirect 를 다르게 해주는 경우만 ReviewFormPage, ReviewPage으로 라우팅할 때 state로 redirect path를 넘겨주고 기본값으로는 OverviewPage로 리다이렉트됨.

### sheet 뷰에서 답변길이가 길면 넘치는 부분 해결

### Overview Page 회고답변목록에서 답변길이가 길면 박스를 뚫고 나가버리는 에러 해결

### 회고 참여자 최근 업데이트 시간이 회고폼의 업데이트 시간으로 잘못 들어간 부분 수정

### 회고 참여자 목록 가로 스크롤 보이지 않도록 수정