### PR TITLE
 회고 수정을 위한 회고 조회시 최신화된 회고폼과 동기화되지 않던 버그 해결

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/common/domain/BaseDate.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/common/domain/BaseDate.java
@@ -24,7 +24,7 @@ public abstract class BaseDate {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    public void renewUpdatedAt(){
+    public void renewUpdatedAt() {
         updatedAt = LocalDateTime.now();
     }
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/config/xss/HTMLCharacterEscapes.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/config/xss/HTMLCharacterEscapes.java
@@ -29,7 +29,7 @@ public class HTMLCharacterEscapes extends CharacterEscapes {
 
     @Override
     public SerializableString getEscapeSequence(int ch) {
-        char charAt = (char) ch;
+        char charAt = (char)ch;
         //emoji jackson parse 오류에 따른 예외 처리
         if (Character.isHighSurrogate(charAt) || Character.isLowSurrogate(charAt)) {
             String convertedEmoji = "\\u" + String.format("%04x", ch);

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
@@ -44,6 +44,17 @@ public class ReviewController {
         return ReviewSummaryResponse.from(reviewService.findById(reviewId));
     }
 
+    @Operation(summary = "특정한 회고 답변 수정시 최신화된 회고폼을 반영하기 위하여 동기화된 회고 답변을 조회한다.")
+    @GetMapping("/{reviewId}/synchronized")
+    @ResponseStatus(HttpStatus.OK)
+    public ReviewSummaryResponse synchronizedFindById(@AuthenticationPrincipal Member member,
+        @PathVariable Long reviewId) {
+
+        info("/api/reviews/" + reviewId + "/synchronize", "GET", "");
+
+        return ReviewSummaryResponse.synchronizedWithReviewForm(reviewService.findById(reviewId));
+    }
+
     @Operation(summary = "회고 답변을 수정한다.")
     @PutMapping("/{reviewId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/QuestionAnswerResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/QuestionAnswerResponse.java
@@ -1,5 +1,7 @@
 package com.reviewduck.review.dto.response;
 
+import java.util.Objects;
+
 import com.reviewduck.review.domain.Answer;
 import com.reviewduck.review.domain.QuestionAnswer;
 import com.reviewduck.review.domain.ReviewFormQuestion;
@@ -25,6 +27,11 @@ public class QuestionAnswerResponse {
     }
 
     public static QuestionAnswerResponse of(ReviewFormQuestion question, Answer answer) {
+
+        if (Objects.isNull(answer)) {
+            return new QuestionAnswerResponse(question.getValue(), null, null);
+        }
+
         return new QuestionAnswerResponse(
             question.getValue(),
             answer.getId(),

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/QuestionAnswerResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/QuestionAnswerResponse.java
@@ -1,6 +1,8 @@
 package com.reviewduck.review.dto.response;
 
+import com.reviewduck.review.domain.Answer;
 import com.reviewduck.review.domain.QuestionAnswer;
+import com.reviewduck.review.domain.ReviewFormQuestion;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,6 +21,14 @@ public class QuestionAnswerResponse {
             questionAnswer.getReviewFormQuestion().getValue(),
             questionAnswer.getAnswer().getId(),
             questionAnswer.getAnswer().getValue()
+        );
+    }
+
+    public static QuestionAnswerResponse of(ReviewFormQuestion question, Answer answer) {
+        return new QuestionAnswerResponse(
+            question.getValue(),
+            answer.getId(),
+            answer.getValue()
         );
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewSummaryResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewSummaryResponse.java
@@ -1,15 +1,22 @@
 package com.reviewduck.review.dto.response;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.reviewduck.review.domain.Answer;
+import com.reviewduck.review.domain.QuestionAnswer;
 import com.reviewduck.review.domain.Review;
+import com.reviewduck.review.domain.ReviewForm;
+import com.reviewduck.review.domain.ReviewFormQuestion;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class ReviewSummaryResponse {
 
@@ -18,6 +25,19 @@ public class ReviewSummaryResponse {
     public static ReviewSummaryResponse from(Review review) {
         List<QuestionAnswerResponse> answers = review.getQuestionAnswers().stream()
             .map(QuestionAnswerResponse::from)
+            .collect(Collectors.toUnmodifiableList());
+
+        return new ReviewSummaryResponse(answers);
+    }
+
+    public static ReviewSummaryResponse synchronizedWithReviewForm(Review review) {
+        ReviewForm reviewForm = review.getReviewForm();
+
+        Map<ReviewFormQuestion, Answer> reviewMap = review.getQuestionAnswers().stream()
+            .collect(Collectors.toUnmodifiableMap(QuestionAnswer::getReviewFormQuestion, QuestionAnswer::getAnswer));
+
+        List<QuestionAnswerResponse> answers = reviewForm.getReviewFormQuestions().stream()
+            .map(question -> QuestionAnswerResponse.of(question, reviewMap.get(question)))
             .collect(Collectors.toUnmodifiableList());
 
         return new ReviewSummaryResponse(answers);

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewSummaryResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewSummaryResponse.java
@@ -37,7 +37,7 @@ public class ReviewSummaryResponse {
             .collect(Collectors.toUnmodifiableMap(QuestionAnswer::getReviewFormQuestion, QuestionAnswer::getAnswer));
 
         List<QuestionAnswerResponse> answers = reviewForm.getReviewFormQuestions().stream()
-            .map(question -> QuestionAnswerResponse.of(question, reviewMap.get(question)))
+            .map(question -> QuestionAnswerResponse.of(question, reviewMap.getOrDefault(question, null)))
             .collect(Collectors.toUnmodifiableList());
 
         return new ReviewSummaryResponse(answers);

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/AnswerService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/AnswerService.java
@@ -3,7 +3,6 @@ package com.reviewduck.review.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.review.domain.Answer;
 import com.reviewduck.review.repository.AnswerRepository;
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
@@ -78,7 +78,8 @@ public class ReviewService {
             ReviewFormQuestion reviewFormQuestion = questionMap.get(answerRequest.getQuestionId());
 
             QuestionAnswer questionAnswer = questionAnswerMap
-                .getOrDefault(reviewFormQuestion, new QuestionAnswer(reviewFormQuestion, answerService.saveNewAnswer()));
+                .getOrDefault(reviewFormQuestion,
+                    new QuestionAnswer(reviewFormQuestion, answerService.saveNewAnswer()));
 
             questionAnswer.getAnswer().update(answerRequest.getAnswerValue());
             updateQuestionAnswers.add(questionAnswer);

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
@@ -98,10 +98,11 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
                 new AnswerRequest(3L, "answer3")));
         post("/api/review-forms/" + code, createRequest, accessToken2);
 
-        // delete question3 of reviewForm
+        // delete question2 and add question4 of reviewForm
         List<ReviewQuestionUpdateRequest> updateQuestions = List.of(
             new ReviewQuestionUpdateRequest(1L, "new question1"),
-            new ReviewQuestionUpdateRequest(3L, "new question3"));
+            new ReviewQuestionUpdateRequest(3L, "new question3"),
+            new ReviewQuestionUpdateRequest(null, "new question4"));
         ReviewFormUpdateRequest updateRequest = new ReviewFormUpdateRequest(reviewTitle, updateQuestions);
         put("/api/review-forms/" + code, updateRequest, accessToken1);
 
@@ -114,11 +115,13 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-            () -> assertThat(actual.size()).isEqualTo(2),
+            () -> assertThat(actual.size()).isEqualTo(3),
             () -> assertThat(actual.get(0).getQuestionValue()).isEqualTo("new question1"),
             () -> assertThat(actual.get(0).getAnswerId()).isEqualTo(1L),
             () -> assertThat(actual.get(1).getQuestionValue()).isEqualTo("new question3"),
-            () -> assertThat(actual.get(1).getAnswerId()).isEqualTo(3L)
+            () -> assertThat(actual.get(1).getAnswerId()).isEqualTo(3L),
+            () -> assertThat(actual.get(2).getQuestionValue()).isEqualTo("new question4"),
+            () -> assertThat(actual.get(2).getAnswerId()).isEqualTo(null)
         );
     }
 


### PR DESCRIPTION
api의 전체적인 리팩토링이 이루어질 예정이니 `GET /api/reviews/{reviewId}/synchronized ` 에 구현해뒀습니다.
추후 api 리팩토링을 진행하며 더 좋은 방식은 없는지 고민해보겠습니다!

간단히 로직을 설명하자면
1. id로 review 조회
2. review의 reviewForm조회
3. review의 question을 key로, answer를  value로 하는 map 선언
4. reviewForm의 question들을 조회하여 3에서 만든 map으로 value 찾기 
    -> 새로 추가된 질문으로써 answer가 존재하지 않는다면 null 반환 
