### PR TITLE
빌드된 파일에 버전명이 기록되도록 설정

### DIFF
--- a/frontend/.webpack/webpack.common.js
+++ b/frontend/.webpack/webpack.common.js
@@ -6,6 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const path = require('path');
+const package = require('../package.json');
 const dotenv = require('dotenv');
 
 module.exports = (env = {}, options = {}) => {
@@ -84,7 +85,7 @@ module.exports = (env = {}, options = {}) => {
         favicon: './public/favicon.ico',
       }),
       new CleanWebpackPlugin(),
-      new MiniCssExtractPlugin({ linkType: false, filename: 'css/[name].[contenthash].css' }),
+      new MiniCssExtractPlugin({ linkType: false, filename: `css/[name].${package.version}.css` }),
     ],
   };
 };

--- a/frontend/.webpack/webpack.prod.js
+++ b/frontend/.webpack/webpack.prod.js
@@ -1,6 +1,7 @@
 const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const path = require('path');
+const package = require('../package.json');
 
 module.exports = (env, options) =>
   merge(common(env, options), {
@@ -9,6 +10,6 @@ module.exports = (env, options) =>
     output: {
       path: path.join(__dirname, '../build'),
       publicPath: process.env.PUBLIC_PATH,
-      filename: `bundle.${Date.now()}.js`,
+      filename: `app.${package.version}.js`,
     },
   });


### PR DESCRIPTION
![스크린샷 2022-08-09 오후 9 12 25](https://user-images.githubusercontent.com/94832610/183644812-83fcc453-2556-4503-a8bd-f8d95aaa6168.png)

프로젝트 빌드 시 번들링된 파일과 스타일 시트에 현재 배포된 버전명이 붙도록 웹팩 설정을 변경하였습니다.

## 변경한 이유
- FE 버전 관리가 자동화 되어있음으로 배포할 때마다 버전명은 지속적으로 업데이트됩니다.
- 사용자의 브라우저에 JS, CSS 파일을 버전 단위로 캐싱 처리를 하는 것이 목표입니다.
- CD가 적용되어있지만, 실제 적용되어있는 버전을 브라우저에서 바로 확인할 수 있게 하기 위해 추가하였습니다.