### PR TITLE
Suspense 중에 Snackbar 깜빡임 현상 해결

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,13 +25,13 @@ function App() {
   // TODO: 전역 페이지 로딩 화면 구현하기, 페이지 단위로 lazy 로드 처리
   return (
     <ContextWrapper>
-      <Suspense>
-        <ErrorBoundary>
-          <SnackbarProvider />
+      <ErrorBoundary>
+        <SnackbarProvider />
+        <Suspense>
           <ModalProvider contentList={modalContentList} />
           <PageRoutes />
-        </ErrorBoundary>
-      </Suspense>
+        </Suspense>
+      </ErrorBoundary>
     </ContextWrapper>
   );
 }


### PR DESCRIPTION
## 문제 상황
간헐적으로 스낵바가 깜빡이는 현상.

![Aug-11-2022 16-59-31](https://user-images.githubusercontent.com/94832610/184089477-db6a6b39-621e-40e5-acbc-8fc152662d68.gif)

## 원인
- SnackbarProvider에 페이지 Suspense가 래핑되어있어 발생된 문제였습니다.
Suspense가 로딩 상태로 인식할 때 fallback prop이 표기되니 SnackbarProvider가 렌더링되지 않아 발생되었습니다.


## Todo
- Modal, Page의 Suspense 분리가 필요할 것 같습니다. 요건 제가 이슈 등록해두고 고치겠습니다!