### PR TITLE
FontAwesome 설치, CheckBox 컴포넌트 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,10 @@
     "pretty": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\""
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.2.0",
+    "@fortawesome/free-regular-svg-icons": "^6.2.0",
+    "@fortawesome/free-solid-svg-icons": "^6.2.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
     "material-icons": "^1.11.4",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta charset="UTF-8" />
-    <meta http-equiv="Cache-Control" content="no-cache" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="회고덕" />
     <meta name="description" content="함께 성장하는 회고 플랫폼." />

--- a/frontend/src/common/components/CheckBox/index.stories.tsx
+++ b/frontend/src/common/components/CheckBox/index.stories.tsx
@@ -1,0 +1,10 @@
+import CheckBox from '.';
+
+export default {
+  title: 'common/components/CheckBox',
+  component: CheckBox,
+};
+
+const Template = () => <CheckBox>테스트입니다</CheckBox>;
+
+export const DefaultFieldSet = Template.bind({});

--- a/frontend/src/common/components/CheckBox/index.stories.tsx
+++ b/frontend/src/common/components/CheckBox/index.stories.tsx
@@ -5,6 +5,6 @@ export default {
   component: CheckBox,
 };
 
-const Template = () => <CheckBox>테스트입니다</CheckBox>;
+const Template = () => <CheckBox onChange={() => alert('변경!')}>테스트입니다</CheckBox>;
 
 export const DefaultFieldSet = Template.bind({});

--- a/frontend/src/common/components/CheckBox/index.tsx
+++ b/frontend/src/common/components/CheckBox/index.tsx
@@ -1,3 +1,5 @@
+import cn from 'classnames';
+
 import styles from './styles.module.scss';
 
 import FlexContainer from '../FlexContainer';
@@ -5,12 +7,13 @@ import { faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
+  className?: string;
   children: string;
 }
 
-function CheckBox({ children, ...rest }: CheckboxProps) {
+function CheckBox({ className, children, ...rest }: CheckboxProps) {
   return (
-    <label className={styles.componentCheckbox}>
+    <label className={cn(styles.componentCheckbox, className)}>
       <input type="checkbox" className={styles.input} {...rest} />
 
       <FlexContainer className={styles.checkbox} align="center" justify="center">

--- a/frontend/src/common/components/CheckBox/index.tsx
+++ b/frontend/src/common/components/CheckBox/index.tsx
@@ -1,0 +1,25 @@
+import styles from './styles.module.scss';
+
+import FlexContainer from '../FlexContainer';
+import { faCheck } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+export interface CheckboxProps extends React.HTMLAttributes<HTMLInputElement> {
+  children: string;
+}
+
+function CheckBox({ children, ...rest }: CheckboxProps) {
+  return (
+    <label className={styles.componentCheckbox}>
+      <input type="checkbox" className={styles.input} {...rest} />
+
+      <FlexContainer className={styles.checkbox} align="center" justify="center">
+        <FontAwesomeIcon className={styles.icon} icon={faCheck} />
+      </FlexContainer>
+
+      <div className={styles.text}>{children}</div>
+    </label>
+  );
+}
+
+export default CheckBox;

--- a/frontend/src/common/components/CheckBox/styles.module.scss
+++ b/frontend/src/common/components/CheckBox/styles.module.scss
@@ -1,0 +1,83 @@
+@import 'styles/@global.scss';
+
+.component-checkbox {
+  cursor: pointer;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  user-select: none;
+  gap: 0.5em;
+
+  .input {
+    display: none;
+  }
+
+  .checkbox {
+    position: relative;
+
+    width: 1.2em;
+    height: 1.2em;
+    border: 0.15em solid $THEME_COLOR_THEME_TEXT_400;
+    border-radius: 0.2em;
+    overflow: hidden;
+
+    .icon {
+      position: relative;
+      visibility: hidden;
+      font-size: 0.9em;
+      color: $THEME_COLOR_STATUS_INNER_PRIMARY_500;
+      z-index: 1;
+      transition: all 0.3s ease;
+
+      opacity: 0;
+      transform: translateY(-100%) scale(0.5);
+    }
+
+    &::before {
+      content: '';
+
+      position: absolute;
+      left: 0;
+      top: 0;
+
+      display: block;
+      width: 100%;
+      height: 100%;
+      background-color: $THEME_COLOR_STATUS_PRIMARY_500;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: 0;
+    }
+  }
+
+  .input:checked + .checkbox {
+    border-width: 0.08em;
+    border-color: $THEME_COLOR_STATUS_PRIMARY_400;
+
+    .icon {
+      visibility: visible;
+
+      opacity: 1;
+      transform: translateY(0);
+    }
+
+    &::before {
+      opacity: 1;
+    }
+  }
+
+  .text {
+    color: $THEME_COLOR_THEME_TEXT_600;
+  }
+
+  &:hover {
+    .checkbox {
+      background-color: $THEME_COLOR_THEME_BACKGROUND_200;
+    }
+
+    .text {
+      color: $THEME_COLOR_THEME_TEXT_900;
+    }
+  }
+}

--- a/frontend/src/common/components/CheckBox/styles.module.scss
+++ b/frontend/src/common/components/CheckBox/styles.module.scss
@@ -46,7 +46,7 @@
       height: 100%;
       background-color: $THEME_COLOR_STATUS_PRIMARY_500;
       opacity: 0;
-      transition: opacity 0.3s ease;
+      transition: opacity 0.2s ease;
       z-index: 0;
     }
   }

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1275,6 +1275,39 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@fortawesome/fontawesome-common-types@6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.2.0.tgz#76467a94aa888aeb22aafa43eb6ff889df3a5a7f"
+  integrity sha512-rBevIsj2nclStJ7AxTdfsa3ovHb1H+qApwrxcTVo+NNdeJiB9V75hsKfrkG5AwNcRUNxrPPiScGYCNmLMoh8pg==
+
+"@fortawesome/fontawesome-svg-core@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.2.0.tgz#11856eaf4dd1d865c442ddea1eed8ee855186ba2"
+  integrity sha512-Cf2mAAeMWFMzpLC7Y9H1I4o3wEU+XovVJhTiNG8ZNgSQj53yl7OCJaS80K4YjrABWZzbAHVaoHE1dVJ27AAYXw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.2.0"
+
+"@fortawesome/free-regular-svg-icons@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.2.0.tgz#947e1f03be17da3a60bfeb2666b5348b19448ce2"
+  integrity sha512-M1dG+PAmkYMTL9BSUHFXY5oaHwBYfHCPhbJ8qj8JELsc9XCrUJ6eEHWip4q0tE+h9C0DVyFkwIM9t7QYyCpprQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.2.0"
+
+"@fortawesome/free-solid-svg-icons@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.2.0.tgz#8dcde48109354fd7a5ece8ea48d678bb91d4b5f0"
+  integrity sha512-UjCILHIQ4I8cN46EiQn0CZL/h8AwCGgR//1c4R96Q5viSRwuKVo0NdQEc4bm+69ZwC0dUvjbDqAHF1RR5FA3XA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.2.0"
+
+"@fortawesome/react-fontawesome@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
+  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
+  dependencies:
+    prop-types "^15.8.1"
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
* 체크박스 컴포넌트의 크기는 상위 컴포넌트 혹은 className에 지정된 폰트 사이즈를 따라가도록 구현하였습니다.
* FontAwesome으로 전환은 추후 최적화 중 일괄 전환하시는거로 가시죠!

---
## 서버 관련 변경사항
* nginx 설정으로 gzip 설정, brotli 설치 & 설정 진행했습니다.