### PR TITLE
회고 좋아요 기능 구현

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/auth/config/AuthenticationPrincipalConfig.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/auth/config/AuthenticationPrincipalConfig.java
@@ -29,7 +29,7 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
             .excludePathPatterns("/api/login/**")
             .excludePathPatterns("/api/review-forms/*/reviews")
             .excludePathPatterns("/api/reviews/public")
-            .excludePathPatterns("/api/reviews/likes");
+            .excludePathPatterns("/api/reviews/*/likes");
     }
 
     @Override

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,7 +24,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.reviewduck.auth.support.AuthenticationPrincipal;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.domain.Review;
+import com.reviewduck.review.dto.request.ReviewLikesRequest;
 import com.reviewduck.review.dto.request.ReviewUpdateRequest;
+import com.reviewduck.review.dto.response.ReviewLikesResponse;
 import com.reviewduck.review.dto.response.ReviewResponse;
 import com.reviewduck.review.dto.response.ReviewSynchronizedResponse;
 import com.reviewduck.review.dto.response.ReviewsResponse;
@@ -99,5 +102,16 @@ public class ReviewController {
         info("/api/reviews/" + reviewId, "DELETE", "");
 
         reviewService.delete(member, reviewId);
+    }
+
+    @Operation(summary = "좋아요 개수를 더한다.")
+    @PostMapping("/likes")
+    @ResponseStatus(HttpStatus.OK)
+    public ReviewLikesResponse likes(@RequestBody @Valid ReviewLikesRequest request) {
+
+        info("/api/reviews/likes", "POST", request.toString());
+
+        int likes = reviewService.increaseLikes(request.getId(), request.getLikes());
+        return new ReviewLikesResponse(likes);
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
@@ -24,7 +24,6 @@ import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.dto.request.ReviewLikesRequest;
 import com.reviewduck.review.dto.request.ReviewUpdateRequest;
 import com.reviewduck.review.dto.response.ReviewLikesResponse;
-import com.reviewduck.review.dto.response.ReviewResponse;
 import com.reviewduck.review.dto.response.ReviewSynchronizedResponse;
 import com.reviewduck.review.dto.response.ReviewsResponse;
 import com.reviewduck.review.dto.response.TimelineReviewsResponse;
@@ -104,13 +103,13 @@ public class ReviewController {
     }
 
     @Operation(summary = "좋아요 개수를 더한다.")
-    @PostMapping("/likes")
+    @PostMapping("/{reviewId}/likes")
     @ResponseStatus(HttpStatus.OK)
-    public ReviewLikesResponse likes(@RequestBody @Valid ReviewLikesRequest request) {
+    public ReviewLikesResponse likes(@PathVariable Long reviewId, @RequestBody @Valid ReviewLikesRequest request) {
 
-        info("/api/reviews/likes", "POST", request.toString());
+        info("/api/reviews/" + reviewId + "/likes", "POST", request.toString());
 
-        int likes = reviewService.increaseLikes(request.getId(), request.getLikes());
+        int likes = reviewService.increaseLikes(reviewId, request.getLikes());
         return new ReviewLikesResponse(likes);
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
@@ -49,6 +49,9 @@ public class Review extends BaseDate {
     @OrderBy("position asc")
     private List<QuestionAnswer> questionAnswers;
 
+    @Column(nullable = false)
+    private int like;
+
     public Review(String title, Member member, ReviewForm reviewForm, List<QuestionAnswer> questionAnswers,
         boolean isPrivate) {
         validate(title);
@@ -82,5 +85,10 @@ public class Review extends BaseDate {
         if (Objects.isNull(title) || title.isBlank()) {
             throw new ReviewException("회고의 제목은 비어있을 수 없습니다.");
         }
+    }
+
+    public int like(int likeCount) {
+        like += likeCount;
+        return like;
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
@@ -50,7 +50,7 @@ public class Review extends BaseDate {
     private List<QuestionAnswer> questionAnswers;
 
     @Column(nullable = false)
-    private int like;
+    private int likes;
 
     public Review(String title, Member member, ReviewForm reviewForm, List<QuestionAnswer> questionAnswers,
         boolean isPrivate) {
@@ -88,7 +88,7 @@ public class Review extends BaseDate {
     }
 
     public int like(int likeCount) {
-        like += likeCount;
-        return like;
+        likes += likeCount;
+        return likes;
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/request/ReviewLikesRequest.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/request/ReviewLikesRequest.java
@@ -1,0 +1,33 @@
+package com.reviewduck.review.dto.request;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Getter
+public class ReviewLikesRequest {
+
+    @NotNull(message = "좋아요 요청 중 오류가 발생했습니다.")
+    private Long id;
+
+    @Min(value = 0, message = "좋아요 개수는 0 이상이어야 합니다.")
+    private int likes;
+
+    @Override
+    public String toString() {
+        return "ReviewLikesRequest{" +
+            "id=" + id +
+            ", likes=" + likes +
+            '}';
+    }
+}

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/request/ReviewLikesRequest.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/request/ReviewLikesRequest.java
@@ -1,11 +1,6 @@
 package com.reviewduck.review.dto.request;
 
-import java.util.List;
-
-import javax.validation.Valid;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -17,17 +12,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ReviewLikesRequest {
 
-    @NotNull(message = "좋아요 요청 중 오류가 발생했습니다.")
-    private Long id;
-
     @Min(value = 0, message = "좋아요 개수는 0 이상이어야 합니다.")
     private int likes;
 
     @Override
     public String toString() {
         return "ReviewLikesRequest{" +
-            "id=" + id +
-            ", likes=" + likes +
+            "likes=" + likes +
             '}';
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewLikesResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewLikesResponse.java
@@ -1,0 +1,11 @@
+package com.reviewduck.review.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ReviewLikesResponse {
+
+    private final int likes;
+}

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import com.reviewduck.member.domain.Member;
@@ -30,6 +32,10 @@ public interface ReviewRepository extends Repository<Review, Long> {
     Page<Review> findByMember(Member member, Pageable pageable);
 
     Page<Review> findByMemberAndIsPrivateFalse(Member member, Pageable pageable);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update Review r set r.likes = r.likes + :likeCount where r.id = :#{#review.id}")
+    void increaseLikes(Review review, int likeCount);
 
     void deleteById(Long id);
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
@@ -107,6 +107,13 @@ public class ReviewService {
     }
 
     @Transactional
+    public int increaseLikes(Long id, int likeCount) {
+        Review review = findById(id);
+        reviewRepository.increaseLikes(review, likeCount);
+        return findById(id).getLikes();
+    }
+
+    @Transactional
     public void delete(Member member, Long id) {
         Review review = findById(id);
         validateMyReview(member, review, "본인이 생성한 회고가 아니면 삭제할 수 없습니다.");

--- a/backend/reviewduck/src/main/resources/database/migration/V15__review_likes.ddl
+++ b/backend/reviewduck/src/main/resources/database/migration/V15__review_likes.ddl
@@ -1,0 +1,2 @@
+alter table review
+    add column likes integer not null;

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
@@ -430,12 +430,15 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
         void increase() {
             // given
             Long reviewId = saveReviewAndGetId(accessToken1, false);
-            ReviewLikesRequest request = new ReviewLikesRequest(reviewId, 50);
+            ReviewLikesRequest request = new ReviewLikesRequest(50);
 
             // when, then
             // 50번씩 두 번 더한다.
-            post("api/reviews/likes", request);
-            post("api/reviews/likes", request)
+            post("api/reviews/" + reviewId + "/likes", request)
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .body("likes", equalTo(50));
+            post("api/reviews/" + reviewId + "/likes", request)
                 .statusCode(HttpStatus.OK.value())
                 .assertThat()
                 .body("likes", equalTo(100));

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
@@ -27,6 +27,7 @@ import com.reviewduck.review.dto.request.ReviewFormCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormQuestionCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormQuestionUpdateRequest;
 import com.reviewduck.review.dto.request.ReviewFormUpdateRequest;
+import com.reviewduck.review.dto.request.ReviewLikesRequest;
 import com.reviewduck.review.dto.request.ReviewUpdateRequest;
 import com.reviewduck.review.dto.response.ReviewContentResponse;
 import com.reviewduck.review.dto.response.ReviewFormCodeResponse;
@@ -384,6 +385,28 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
             //when, then
             delete("/api/reviews/" + reviewId, accessToken2)
                 .statusCode(HttpStatus.UNAUTHORIZED.value());
+        }
+
+    }
+
+    @Nested
+    @DisplayName("좋아요")
+    class likes {
+
+        @Test
+        @DisplayName("좋아요를 더한다.")
+        void increase() {
+            // given
+            Long reviewId = saveReviewAndGetId(accessToken1, false);
+            ReviewLikesRequest request = new ReviewLikesRequest(reviewId, 50);
+
+            // when, then
+            // 50번씩 두 번 더한다.
+            post("api/reviews/likes", request);
+            post("api/reviews/likes", request)
+                .statusCode(HttpStatus.OK.value())
+                .assertThat()
+                .body("likes", equalTo(100));
         }
 
     }

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/controller/ReviewControllerTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/controller/ReviewControllerTest.java
@@ -135,25 +135,14 @@ public class ReviewControllerTest {
     @DisplayName("좋아요")
     class likes {
 
-        @ParameterizedTest
-        @NullSource
-        @DisplayName("회고 id에 null 값이 들어갈 경우 예외가 발생한다.")
-        void nullContent(Long reviewId) throws Exception {
-            // given
-            ReviewLikesRequest request = new ReviewLikesRequest(reviewId, 0);
-
-            // when, then
-            assertBadRequestFromPost("/api/reviews/likes", request, "좋아요 요청 중 오류가 발생했습니다.");
-        }
-
         @Test
-        @DisplayName("좋아요 개수는 음수일 수 없습니다.")
+        @DisplayName("좋아요 개수는 음수일 수 없다.")
         void notNegative() throws Exception {
             // given
-            ReviewLikesRequest request = new ReviewLikesRequest(1L, -1);
+            ReviewLikesRequest request = new ReviewLikesRequest(-1);
 
             // when, then
-            assertBadRequestFromPost("/api/reviews/likes", request, "좋아요 개수는 0 이상이어야 합니다.");
+            assertBadRequestFromPost("/api/reviews/1/likes", request, "좋아요 개수는 0 이상이어야 합니다.");
         }
 
     }

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/controller/ReviewControllerTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/controller/ReviewControllerTest.java
@@ -54,27 +54,6 @@ public class ReviewControllerTest {
         given(memberService.findById(any())).willReturn(member);
     }
 
-    private void assertBadRequestFromPost(String uri, Object request, String errorMessage) throws
-        Exception {
-        mockMvc.perform(post(uri)
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("UTF-8")
-                .content(objectMapper.writeValueAsString(request))
-            ).andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.message", containsString(errorMessage)));
-    }
-
-    private void assertBadRequestFromPut(String uri, Object request, String errorMessage) throws Exception {
-        mockMvc.perform(put(uri)
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .characterEncoding("UTF-8")
-                .content(objectMapper.writeValueAsString(request))
-            ).andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.message", containsString(errorMessage)));
-    }
-
     @Nested
     @DisplayName("회고 수정 시")
     class updateReview {
@@ -129,8 +108,8 @@ public class ReviewControllerTest {
             assertBadRequestFromPut("/api/reviews/" + invalidReviewId, request, "답변은 비어있을 수 없습니다.");
         }
 
-    }
 
+    }
     @Nested
     @DisplayName("좋아요")
     class likes {
@@ -145,5 +124,27 @@ public class ReviewControllerTest {
             assertBadRequestFromPost("/api/reviews/1/likes", request, "좋아요 개수는 0 이상이어야 합니다.");
         }
 
+
+    }
+
+    private void assertBadRequestFromPost(String uri, Object request, String errorMessage) throws
+        Exception {
+        mockMvc.perform(post(uri)
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(objectMapper.writeValueAsString(request))
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", containsString(errorMessage)));
+    }
+
+    private void assertBadRequestFromPut(String uri, Object request, String errorMessage) throws Exception {
+        mockMvc.perform(put(uri)
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(objectMapper.writeValueAsString(request))
+            ).andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message", containsString(errorMessage)));
     }
 }

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/domain/ReviewTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/domain/ReviewTest.java
@@ -81,4 +81,28 @@ public class ReviewTest {
         //then
         assertThat(actual).isEqualTo(expected);
     }
+
+    @Test
+    @DisplayName("좋아요를 추가한다.")
+    void like() {
+        // given
+        Review review = new Review(
+            "title",
+            member,
+            reviewForm,
+            List.of(
+                new QuestionAnswer(new ReviewFormQuestion("question1", "description1"), new Answer("answer1")),
+                new QuestionAnswer(new ReviewFormQuestion("question2", "description2"), new Answer("answer2")),
+                new QuestionAnswer(new ReviewFormQuestion("question3", "description3"), new Answer("answer3"))
+            ), false);
+
+        // when
+        int likeCount = 50;
+        // 50씩 두 번 업데이트
+        review.like(likeCount);
+        int actual = review.like(likeCount);
+
+        // then
+        assertThat(actual).isEqualTo(100);
+    }
 }

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
@@ -3,10 +3,8 @@ package com.reviewduck.review.repository;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -186,6 +184,29 @@ public class ReviewRepositoryTest {
 
         // then
         assertThat(actual).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("좋아요 수를 더해도 수정 시간이 갱신되지 않는다.")
+    void increaseLikesWithNotUpdatedAt() throws InterruptedException {
+        // given
+        Review savedReview = saveReview(savedMember, savedReviewForm, false);
+        Long id = savedReview.getId();
+
+        // when
+        // 초기 수정 시간
+        // DB에 들어가서 뒷 자리수가 반올림 된 결과로 비교해야 하기 때문에 조회한다.
+        LocalDateTime updatedAt = reviewRepository.findById(id).orElseThrow()
+            .getUpdatedAt();
+
+        reviewRepository.increaseLikes(savedReview, 50);
+
+        // 좋아요 더한 후 수정 시간
+        LocalDateTime updatedAtAfterIncreaseLikes = reviewRepository.findById(id).orElseThrow()
+            .getUpdatedAt();
+
+        // then
+        assertThat(updatedAtAfterIncreaseLikes.isEqual(updatedAt)).isTrue();
     }
 
     private Review saveReview(Member member, ReviewForm savedReviewForm, boolean isPrivate) throws

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +40,9 @@ public class ReviewRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @PersistenceContext
+    private EntityManager em;
 
     private ReviewForm savedReviewForm;
 
@@ -196,6 +202,7 @@ public class ReviewRepositoryTest {
         // when
         // 초기 수정 시간
         // DB에 들어가서 뒷 자리수가 반올림 된 결과로 비교해야 하기 때문에 조회한다.
+        em.clear();
         LocalDateTime updatedAt = reviewRepository.findById(id).orElseThrow()
             .getUpdatedAt();
 
@@ -204,7 +211,6 @@ public class ReviewRepositoryTest {
         // 좋아요 더한 후 수정 시간
         LocalDateTime updatedAtAfterIncreaseLikes = reviewRepository.findById(id).orElseThrow()
             .getUpdatedAt();
-
         // then
         assertThat(updatedAtAfterIncreaseLikes.isEqual(updatedAt)).isTrue();
     }


### PR DESCRIPTION
특정 사용자를 식별하는 좋아요가 아니라 재미 요소로 비로그인 유저도 요청할 수 있으며, 계속 증가할 수 있는 좋아요를 구현했습니다. 

요청에 ReviewId는 필수이며 likeCount는 0 이상의 값을 받습니다. 

계속된 요청에 의한 부하 제한은 WAS 전체적인 부하 제한을 설정할 때 하면 좋을 것 같습니다.  