### PR TITLE
오버뷰 페이지네이션 적용

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/admin/controller/AdminReviewController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/admin/controller/AdminReviewController.java
@@ -25,8 +25,6 @@ import com.reviewduck.common.util.Logging;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.domain.ReviewForm;
-import com.reviewduck.review.service.ReviewFormService;
-import com.reviewduck.review.service.ReviewService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.AllArgsConstructor;
@@ -40,8 +38,6 @@ public class AdminReviewController {
 
     private final AdminReviewService adminReviewService;
     private final AdminReviewFormService adminReviewFormService;
-    private final ReviewFormService reviewFormService;
-    private final ReviewService reviewService;
 
     @Operation(summary = "생성된 회고 폼을 모두 조회한다")
     @GetMapping("/review-forms")
@@ -79,8 +75,8 @@ public class AdminReviewController {
         Logging.info("api/admin/review-forms/" + reviewFormCode, "GET", "");
 
         validateAdmin(member);
-        ReviewForm reviewForm = reviewFormService.findByCode(reviewFormCode);
-        List<Review> reviews = reviewService.findAllByCode(reviewFormCode);
+        ReviewForm reviewForm = adminReviewFormService.findByCode(reviewFormCode);
+        List<Review> reviews = adminReviewService.findAllByReviewForm(reviewForm);
 
         return AdminReviewFormResponse.of(reviewForm, reviews);
     }
@@ -117,7 +113,7 @@ public class AdminReviewController {
         Logging.info("api/admin/reviews/" + reviewId, "GET", "");
 
         validateAdmin(member);
-        Review review = reviewService.findById(reviewId);
+        Review review = adminReviewService.findById(reviewId);
 
         return AdminReviewResponse.from(review);
     }

--- a/backend/reviewduck/src/main/java/com/reviewduck/admin/repository/AdminReviewFormRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/admin/repository/AdminReviewFormRepository.java
@@ -14,6 +14,8 @@ public interface AdminReviewFormRepository extends Repository<ReviewForm, Long> 
 
     List<ReviewForm> findAllByMember(Member member);
 
+    ReviewForm findByCode(String reviewFormCode);
+
     Optional<ReviewForm> findById(Long reviewFormId);
 
     void delete(ReviewForm reviewForm);

--- a/backend/reviewduck/src/main/java/com/reviewduck/admin/repository/AdminReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/admin/repository/AdminReviewRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.Repository;
 
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.domain.Review;
+import com.reviewduck.review.domain.ReviewForm;
 
 public interface AdminReviewRepository extends Repository<Review, Long> {
 
@@ -14,7 +15,9 @@ public interface AdminReviewRepository extends Repository<Review, Long> {
 
     List<Review> findAllByMember(Member member);
 
+    List<Review> findAllByReviewForm(ReviewForm reviewForm);
+
     Optional<Review> findById(Long reviewId);
 
-    void deleteById(Long reviewId);
+    void delete(Review review);
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/admin/service/AdminReviewFormService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/admin/service/AdminReviewFormService.java
@@ -25,6 +25,10 @@ public class AdminReviewFormService {
         return reviewFormRepository.findAll();
     }
 
+    public ReviewForm findByCode(String reviewFormCode) {
+        return reviewFormRepository.findByCode(reviewFormCode);
+    }
+
     public List<ReviewForm> findByMemberId(Long memberId) {
         Member member = adminMemberService.findMemberById(memberId);
         return reviewFormRepository.findAllByMember(member);

--- a/backend/reviewduck/src/main/java/com/reviewduck/admin/service/AdminReviewService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/admin/service/AdminReviewService.java
@@ -9,6 +9,7 @@ import com.reviewduck.admin.repository.AdminReviewRepository;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.domain.Review;
+import com.reviewduck.review.domain.ReviewForm;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,16 +26,24 @@ public class AdminReviewService {
         return reviewRepository.findAll();
     }
 
+    public Review findById(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 회고입니다."));
+    }
+
     public List<Review> findByMemberId(Long memberId) {
         Member member = adminMemberService.findMemberById(memberId);
         return reviewRepository.findAllByMember(member);
     }
 
+    public List<Review> findAllByReviewForm(ReviewForm reviewForm) {
+        return reviewRepository.findAllByReviewForm(reviewForm);
+    }
+
     @Transactional
     public void deleteReviewById(Long reviewId) {
-        reviewRepository.findById(reviewId)
-            .orElseThrow(() -> new NotFoundException("존재하지 않는 회고입니다."));
+        Review review = findById(reviewId);
 
-        reviewRepository.deleteById(reviewId);
+        reviewRepository.delete(review);
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
@@ -3,8 +3,6 @@ package com.reviewduck.review.controller;
 import static com.reviewduck.common.util.Logging.*;
 import static com.reviewduck.template.vo.TemplatePageConstant.*;
 
-import java.util.List;
-
 import javax.validation.Valid;
 
 import org.springframework.data.domain.Page;
@@ -28,9 +26,9 @@ import com.reviewduck.review.dto.request.ReviewCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormUpdateRequest;
 import com.reviewduck.review.dto.response.MemberReviewFormsResponse;
-import com.reviewduck.review.dto.response.ReviewAbstractResponse;
 import com.reviewduck.review.dto.response.ReviewFormCodeResponse;
 import com.reviewduck.review.dto.response.ReviewFormResponse;
+import com.reviewduck.review.dto.response.ReviewsOfReviewFormResponse;
 import com.reviewduck.review.service.ReviewFormService;
 import com.reviewduck.review.service.ReviewService;
 
@@ -99,15 +97,17 @@ public class ReviewFormController {
     @Operation(summary = "특정 회고 폼을 기반으로 작성된 회고 답변들을 모두 조회한다.")
     @GetMapping(value = "/{reviewFormCode}/reviews")
     @ResponseStatus(HttpStatus.OK)
-    public List<ReviewAbstractResponse> findReviewsByCodeAsListDisplay(@AuthenticationPrincipal Member member,
-        @PathVariable String reviewFormCode, @RequestParam String displayType) {
+    public ReviewsOfReviewFormResponse findReviewsByCodeAsListDisplay(@AuthenticationPrincipal Member member,
+        @PathVariable String reviewFormCode,
+        @RequestParam(required = false, defaultValue = DEFAULT_PAGE) Integer page,
+        @RequestParam(required = false, defaultValue = DEFAULT_SIZE) Integer size,
+        @RequestParam String displayType) {
 
         info("/api/review-forms/" + reviewFormCode + "/reviews?displayType=" + displayType, "GET", "");
 
-        List<Review> reviews = reviewService.findAllByCode(reviewFormCode);
+        Page<Review> reviews = reviewService.findAllByCode(reviewFormCode, page - 1, size);
 
-        return ReviewDisplayBuilder.of(displayType)
-            .createResponseFrom(member, reviews);
+        return ReviewsOfReviewFormResponse.of(member, reviews, displayType);
     }
 
     @Operation(summary = "회고 폼을 수정한다.")

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewDisplayBuilder.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewDisplayBuilder.java
@@ -1,4 +1,4 @@
-package com.reviewduck.review.controller;
+package com.reviewduck.review.dto.response;
 
 import java.util.Arrays;
 import java.util.List;
@@ -7,9 +7,6 @@ import java.util.stream.Collectors;
 
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.domain.Review;
-import com.reviewduck.review.dto.response.ReviewAbstractResponse;
-import com.reviewduck.review.dto.response.ReviewResponse;
-import com.reviewduck.review.dto.response.ReviewSheetResponse;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewsOfReviewFormResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewsOfReviewFormResponse.java
@@ -1,0 +1,30 @@
+package com.reviewduck.review.dto.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.reviewduck.member.domain.Member;
+import com.reviewduck.review.domain.Review;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class ReviewsOfReviewFormResponse {
+
+    private long numberOfReviews;
+    private List<ReviewAbstractResponse> reviews;
+
+    public static ReviewsOfReviewFormResponse of(Member member, Page<Review> reviews, String displayType) {
+        List<ReviewAbstractResponse> reviewResponses = ReviewDisplayBuilder.of(displayType)
+            .createResponseFrom(member, reviews.getContent());
+
+        return new ReviewsOfReviewFormResponse(reviews.getTotalElements(), reviewResponses);
+    }
+
+}

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package com.reviewduck.review.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -19,7 +18,7 @@ public interface ReviewRepository extends Repository<Review, Long> {
 
     Optional<Review> findById(long reviewId);
 
-    List<Review> findByReviewForm(ReviewForm reviewForm);
+    Page<Review> findByReviewForm(ReviewForm reviewForm, Pageable pageable);
 
     Page<Review> findByIsPrivateFalse(Pageable pageable);
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
@@ -54,7 +54,7 @@ public class ReviewService {
             .orElseThrow(() -> new NotFoundException("존재하지 않는 회고입니다."));
     }
 
-    public Page<Review> findBySocialId(String socialId, Member member, Integer page, Integer size) {
+    public Page<Review> findBySocialId(String socialId, Member member, int page, int size) {
         String sortType = "updatedAt";
 
         Member owner = memberService.getBySocialId(socialId);
@@ -68,9 +68,13 @@ public class ReviewService {
 
     }
 
-    public List<Review> findAllByCode(String code) {
+    public Page<Review> findAllByCode(String code, int page, int size) {
+        String sortType = "updatedAt";
+
         ReviewForm reviewForm = reviewFormService.findByCode(code);
-        return reviewRepository.findByReviewForm(reviewForm);
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, sortType));
+
+        return reviewRepository.findByReviewForm(reviewForm, pageRequest);
     }
 
     public Page<Review> findAllPublic(int page, int size, String sort) {

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
@@ -5,9 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,13 +68,15 @@ public class ReviewRepositoryTest {
     }
 
     @Test
-    @DisplayName("특정 회고 폼을 기반으로 작성된 회고를 모두 조회한다.")
+    @DisplayName("특정 회고 폼을 기반으로 작성된 회고 중 특정 페이지를 조회한다.")
     void findReviewsBySpecificReviewForm() throws InterruptedException {
         // given
         Review savedReview = saveReview(savedMember, savedReviewForm, false);
+        saveReview(savedMember, savedReviewForm, true);
 
         // when
-        List<Review> reviews = reviewRepository.findByReviewForm(savedReviewForm);
+        PageRequest pageRequest = PageRequest.of(1, 1);
+        List<Review> reviews = reviewRepository.findByReviewForm(savedReviewForm, pageRequest).getContent();
 
         // then
         assertAll(

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewServiceTest.java
@@ -250,19 +250,23 @@ public class ReviewServiceTest {
     class findByCode {
 
         @Test
-        @DisplayName("특정 회고 폼을 기반으로 작성된 회고를 모두 조회한다.")
-        void findByReviewFormCode() throws InterruptedException {
+        @DisplayName("최신순으로 특정 페이지를 조회한다.")
+        void findAllOrderByTrend() throws InterruptedException {
             // given
-            Review savedReview = saveReview(member1, false);
+            saveReview(member1, false);
+            Review review = saveReview(member2, true);
+            saveReview(member1, true);
 
             // when
-            List<Review> reviews = reviewService.findAllByCode(reviewForm.getCode());
+            Integer page = 1;
+            Integer size = 1;
+
+            List<Review> reviews = reviewService.findAllByCode(reviewForm.getCode(), page, size).getContent();
 
             // then
             assertAll(
                 () -> assertThat(reviews).hasSize(1),
-                () -> assertThat(reviews.get(0).getMember().getNickname()).isEqualTo(
-                    savedReview.getMember().getNickname())
+                () -> assertThat(reviews.get(0)).isEqualTo(review)
             );
         }
 
@@ -270,7 +274,7 @@ public class ReviewServiceTest {
         @DisplayName("존재하지 않는 회고 폼으로 조회할 수 없다.")
         void invalidCode() {
             // when, then
-            assertThatThrownBy(() -> reviewService.findAllByCode("aaaaaa"))
+            assertThatThrownBy(() -> reviewService.findAllByCode("aaaaaa", 0, 1))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 회고 폼입니다.");
         }
@@ -295,9 +299,6 @@ public class ReviewServiceTest {
             String sort = "latest";
 
             List<Review> reviews = reviewService.findAllPublic(page, size, sort).getContent();
-
-            System.out.println(review);
-            System.out.println(reviews.get(0));
 
             // then
             assertAll(
@@ -419,7 +420,7 @@ public class ReviewServiceTest {
             reviewService.delete(member1, savedReview.getId());
 
             // then
-            assertThat(reviewService.findAllByCode(reviewForm.getCode())).hasSize(0);
+            assertThat(reviewService.findAllByCode(reviewForm.getCode(), 0, 1)).hasSize(0);
         }
 
         @Test


### PR DESCRIPTION
- admin에서 adminService가 아닌 비즈니스 로직의 Service를 사용하고 있어 변경했습니다.
- 테스트의 private 메서드가 클래스 상단에 위치한 경우가 있는 것 같아요. 누군가의 code formatter 때문인가 싶은데 각자 한번씩 확인해보면 좋을 것 같습니다!
- 현재 acceptanceTest의 검증 과정이 extract.as(객체.class) 와 assert().body(~~) 이 두 가지 방식으로 혼동되어 있습니다. 통일할지 혹은 때에 맞춰 알아서 구현할지 같이 고민해보면 좋을 것 같아요.
- admin에 deleteReviewById() 메서드에서 바로 id로 삭제하는 것이 아니라 findById로 한번 찾도록 구현한건 id가 존재하지 않는 경우 예외가 나길 바라신 의도인지 궁금해요~
- 페이지네이션에서 page, size 등의 파라미터를 Integer로 받고있는데 default 값도 있으니 int로 바꾸는 것에 대해 다들 어떻게 생각하는지 궁금해요.
- ReviewResponse의 반환 형식이 변경됨에 따라 ReviewDisplayBuilder를 컨트롤러가 아닌 dto에서 호출하게되었어요. 그래서 패키지를 response 안으로 변경했습니다!