### PR TITLE
TimelinePage, OverviewPage 무한스크롤 구현

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -21,6 +21,7 @@
     "react/react-in-jsx-scope": "off",
     "jsx-a11y/no-noninteractive-element-interactions": "off",
     "jsx-a11y/click-events-have-key-events": "off",
-    "jsx-a11y/no-static-element-interactions": "off"
+    "jsx-a11y/no-static-element-interactions": "off",
+    "react/prop-types": "off"
   }
 }

--- a/frontend/src/api/review.api.ts
+++ b/frontend/src/api/review.api.ts
@@ -25,13 +25,13 @@ export const getFormAnswer = async (
   return transformer.transformFormAnswer(data);
 };
 
-/* TODO: sort 파라미터가 추가돼야 함 */
 export const getPublicAnswer = async (
   pageNumber: string,
   size: number,
+  filter: ReviewType.TimelineFilterType = 'trend',
 ): Promise<ReviewType.ReviewPublicAnswerList> => {
   const { data } = await axiosInstance.get(
-    `${API_URI.REVIEW.GET_PUBLIC_ANSWER}?page=${pageNumber}&size=${size}`,
+    `${API_URI.REVIEW.GET_PUBLIC_ANSWER}?page=${pageNumber}&size=${size}&sort=${filter}`,
   );
 
   return transformer.transformPublicAnswer(data);

--- a/frontend/src/api/review.api.ts
+++ b/frontend/src/api/review.api.ts
@@ -17,10 +17,14 @@ export const getAnswer = async (reviewId: number): Promise<ReviewType.ReviewAnsw
 };
 
 export const getFormAnswer = async (
+  pageNumber: string,
+  size: number,
   reviewFormCode = '',
-  display = 'list',
+  display: ReviewType.DisplayModeType = 'list',
 ): Promise<ReviewType.ReviewFormAnswerList> => {
-  const { data } = await axiosInstance.get(API_URI.REVIEW.GET_FORM_ANSWER(reviewFormCode, display));
+  const { data } = await axiosInstance.get(
+    API_URI.REVIEW.GET_FORM_ANSWER(reviewFormCode, display, pageNumber, size),
+  );
 
   return transformer.transformFormAnswer(data);
 };

--- a/frontend/src/api/review.api.ts
+++ b/frontend/src/api/review.api.ts
@@ -25,8 +25,14 @@ export const getFormAnswer = async (
   return transformer.transformFormAnswer(data);
 };
 
-export const getPublicAnswer = async (): Promise<ReviewType.ReviewPublicAnswerList> => {
-  const { data } = await axiosInstance.get(API_URI.REVIEW.GET_PUBLIC_ANSWER);
+/* TODO: sort 파라미터가 추가돼야 함 */
+export const getPublicAnswer = async (
+  pageNumber: string,
+  size: number,
+): Promise<ReviewType.ReviewPublicAnswerList> => {
+  const { data } = await axiosInstance.get(
+    `${API_URI.REVIEW.GET_PUBLIC_ANSWER}?page=${pageNumber}&size=${size}`,
+  );
 
   return transformer.transformPublicAnswer(data);
 };

--- a/frontend/src/api/review.transformer.ts
+++ b/frontend/src/api/review.transformer.ts
@@ -71,7 +71,7 @@ export const transformFormAnswer = (data: GetReviewFormAnswerResponse): ReviewFo
 export const transformPublicAnswer = (
   data: GetReviewPublicAnswerResponse,
 ): ReviewPublicAnswerList => {
-  const { numberOfReviews, reviews } = data;
+  const { isLastPage, numberOfReviews, reviews } = data;
 
   const transformReviews = reviews.map((review) => {
     const { id, reviewFormCode, contents, creator, isCreator, updatedAt, likes } = review;
@@ -94,5 +94,5 @@ export const transformPublicAnswer = (
     };
   });
 
-  return { numberOfReviews, reviews: transformReviews };
+  return { isLastPage, numberOfReviews, reviews: transformReviews };
 };

--- a/frontend/src/api/review.transformer.ts
+++ b/frontend/src/api/review.transformer.ts
@@ -12,11 +12,12 @@ import {
 import { getElapsedTimeText } from 'service/@shared/utils';
 
 export const transformForm = (data: GetReviewFormResponse): ReviewForm => {
-  const { reviewFormTitle, questions, creator, isCreator, updatedAt } = data;
+  const { reviewFormTitle, questions, creator, isCreator, updatedAt, participants } = data;
 
   return {
     title: reviewFormTitle,
     questions,
+    participants,
     info: {
       creator,
       isSelf: isCreator,
@@ -46,9 +47,9 @@ export const transformAnswer = (data: GetReviewAnswerResponse): ReviewAnswer => 
 };
 
 export const transformFormAnswer = (data: GetReviewFormAnswerResponse): ReviewFormAnswerList => {
-  const { numberOfReviews, reviews } = data;
+  const { numberOfReviews, isLastPage, reviews } = data;
 
-  return reviews.map((review) => {
+  const transformReviews = reviews.map((review) => {
     const { id, reviewTitle, updatedAt, likes, isCreator, creator, contents } = review;
 
     return {
@@ -66,6 +67,8 @@ export const transformFormAnswer = (data: GetReviewFormAnswerResponse): ReviewFo
       },
     };
   });
+
+  return { isLastPage, reviews: transformReviews };
 };
 
 export const transformPublicAnswer = (

--- a/frontend/src/constant/index.ts
+++ b/frontend/src/constant/index.ts
@@ -69,15 +69,20 @@ const ACCESS_TOKEN_REFRESH_TIME = ACCESS_TOKEN_EXPIRE_TIME - 60 * 2 * 1000;
 
 const PERMISSION_VALID_TIME = 60 * 1000;
 
-const USER_PROFILE_TAB = {
-  REVIEWS: 'reviews',
-  REVIEW_FORMS: 'review-forms',
-  TEMPLATES: 'templates',
-};
-
-const TEMPLATE_TAB = {
-  TREND: 'trend',
-  LATEST: 'latest',
+const TAB = {
+  USER_PROFILE: {
+    REVIEWS: 'reviews',
+    REVIEW_FORMS: 'review-forms',
+    TEMPLATES: 'templates',
+  },
+  TEMPLATE: {
+    TREND: 'trend',
+    LATEST: 'latest',
+  },
+  TIMELINE: {
+    TREND: 'trend',
+    LATEST: 'latest',
+  },
 };
 
 const REVIEW_FORM_TITLE_LENGTH = 100;
@@ -152,8 +157,7 @@ export {
   ACCESS_PERMISSION,
   ACCESS_TOKEN_EXPIRE_TIME,
   ACCESS_TOKEN_REFRESH_TIME,
-  USER_PROFILE_TAB,
-  TEMPLATE_TAB,
+  TAB,
   PERMISSION_VALID_TIME,
   REVIEW_FORM_TITLE_LENGTH,
   REVIEW_FORM_CODE_LENGTH,

--- a/frontend/src/constant/index.ts
+++ b/frontend/src/constant/index.ts
@@ -69,19 +69,23 @@ const ACCESS_TOKEN_REFRESH_TIME = ACCESS_TOKEN_EXPIRE_TIME - 60 * 2 * 1000;
 
 const PERMISSION_VALID_TIME = 60 * 1000;
 
-const TAB = {
-  USER_PROFILE: {
+const FILTER = {
+  USER_PROFILE_TAB: {
     REVIEWS: 'reviews',
     REVIEW_FORMS: 'review-forms',
     TEMPLATES: 'templates',
   },
-  TEMPLATE: {
+  TEMPLATE_TAB: {
     TREND: 'trend',
     LATEST: 'latest',
   },
-  TIMELINE: {
+  TIMELINE_TAB: {
     TREND: 'trend',
     LATEST: 'latest',
+  },
+  DISPLAY_MODE: {
+    LIST: 'list',
+    SHEET: 'sheet',
   },
 };
 
@@ -111,8 +115,8 @@ const API_URI = {
   REVIEW: {
     GET_FORM: (reviewFormCode: string) => `/api/review-forms/${reviewFormCode}`,
     GET_ANSWER: (reviewId: numberString) => `/api/reviews/${reviewId}`,
-    GET_FORM_ANSWER: (reviewFormCode: string, display: string) =>
-      `/api/review-forms/${reviewFormCode}/reviews?displayType=${display}`,
+    GET_FORM_ANSWER: (reviewFormCode: string, display: string, page?: string, size?: number) =>
+      `/api/review-forms/${reviewFormCode}/reviews?displayType=${display}&page=${page}&size=${size}`,
     GET_PUBLIC_ANSWER: '/api/reviews/public',
 
     CREATE_FORM: '/api/review-forms',
@@ -157,7 +161,7 @@ export {
   ACCESS_PERMISSION,
   ACCESS_TOKEN_EXPIRE_TIME,
   ACCESS_TOKEN_REFRESH_TIME,
-  TAB,
+  FILTER,
   PERMISSION_VALID_TIME,
   REVIEW_FORM_TITLE_LENGTH,
   REVIEW_FORM_CODE_LENGTH,

--- a/frontend/src/mocks/handlers/template.ts
+++ b/frontend/src/mocks/handlers/template.ts
@@ -1,5 +1,4 @@
-import { TEMPLATE_TAB } from 'constant';
-import { API_URI } from 'constant';
+import { API_URI, TAB } from 'constant';
 import { rest } from 'msw';
 
 import { dummyTemplates, dummyTemplate, dummyFormcode } from 'mocks/data';
@@ -7,7 +6,7 @@ import { reviewduckAPI } from 'mocks/hosts';
 
 const templateHandlers = [
   rest.get(reviewduckAPI(API_URI.TEMPLATE.GET_TEMPLATES), (req, res, ctx) => {
-    if (req.url.searchParams.get('filter') === TEMPLATE_TAB.TREND) {
+    if (req.url.searchParams.get('filter') === TAB.TEMPLATE.TREND) {
       const copyTemplates = [...dummyTemplates.templates];
       const sortedTemplates = copyTemplates.sort(
         (first, second) => second.info.usedCount - first.info.usedCount,

--- a/frontend/src/mocks/handlers/template.ts
+++ b/frontend/src/mocks/handlers/template.ts
@@ -1,4 +1,4 @@
-import { API_URI, TAB } from 'constant';
+import { API_URI, FILTER } from 'constant';
 import { rest } from 'msw';
 
 import { dummyTemplates, dummyTemplate, dummyFormcode } from 'mocks/data';
@@ -6,7 +6,7 @@ import { reviewduckAPI } from 'mocks/hosts';
 
 const templateHandlers = [
   rest.get(reviewduckAPI(API_URI.TEMPLATE.GET_TEMPLATES), (req, res, ctx) => {
-    if (req.url.searchParams.get('filter') === TAB.TEMPLATE.TREND) {
+    if (req.url.searchParams.get('filter') === FILTER.TEMPLATE_TAB.TREND) {
       const copyTemplates = [...dummyTemplates.templates];
       const sortedTemplates = copyTemplates.sort(
         (first, second) => second.info.usedCount - first.info.usedCount,

--- a/frontend/src/service/@shared/hooks/queries/review/useGet.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useGet.ts
@@ -1,15 +1,16 @@
+import { useInfiniteQuery, useQuery, UseQueryOptions } from '@tanstack/react-query';
+
 import { reviewAPI } from 'api';
-import { QUERY_KEY } from 'constant';
+import { PAGE_OPTION, QUERY_KEY } from 'constant';
 import {
   ErrorResponse,
+  InfiniteItem,
   ReviewAnswer,
   ReviewForm,
   ReviewFormAnswerList,
   ReviewPublicAnswerList,
 } from 'types';
 import 'types';
-
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 
 function useGetReviewForm(
   reviewFormCode: string,
@@ -55,16 +56,30 @@ function useGetReviewFormAnswer(
   );
 }
 
-function useGetReviewPublicAnswer(
-  queryOptions?: UseQueryOptions<ReviewPublicAnswerList, ErrorResponse>,
-) {
-  return useQuery<ReviewPublicAnswerList, ErrorResponse>(
+function useGetInfiniteReviewPublicAnswer(queryOptions?: any) {
+  const fetchFunc = async ({ pageParam = 1 }) => {
+    const data = await reviewAPI.getPublicAnswer(String(pageParam), PAGE_OPTION.REVIEW_ITEM_SIZE);
+
+    return {
+      data,
+      currentPage: pageParam,
+    };
+  };
+
+  return useInfiniteQuery<InfiniteItem<ReviewPublicAnswerList>>(
     [QUERY_KEY.DATA.REVIEW, QUERY_KEY.API.GET_REVIEW_PUBLIC_ANSWER],
-    () => reviewAPI.getPublicAnswer(),
+    fetchFunc,
     {
+      getNextPageParam: (lastItem) =>
+        lastItem.data.isLastPage ? undefined : lastItem.currentPage + 1,
       ...queryOptions,
     },
   );
 }
 
-export { useGetReviewForm, useGetReviewFormAnswer, useGetReviewAnswer, useGetReviewPublicAnswer };
+export {
+  useGetReviewForm,
+  useGetReviewFormAnswer,
+  useGetReviewAnswer,
+  useGetInfiniteReviewPublicAnswer,
+};

--- a/frontend/src/service/@shared/hooks/queries/review/useGet.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useGet.ts
@@ -3,6 +3,7 @@ import { useInfiniteQuery, useQuery, UseQueryOptions } from '@tanstack/react-que
 import { reviewAPI } from 'api';
 import { PAGE_OPTION, QUERY_KEY } from 'constant';
 import {
+  DisplayModeType,
   ErrorResponse,
   InfiniteItem,
   ReviewAnswer,
@@ -39,19 +40,31 @@ function useGetReviewAnswer(
   );
 }
 
-interface UseGetReviewFormAnswer {
-  reviewFormCode: string;
-  display?: string;
-}
-
-function useGetReviewFormAnswer(
-  { reviewFormCode, display }: UseGetReviewFormAnswer,
-  queryOptions?: UseQueryOptions<ReviewFormAnswerList, ErrorResponse>,
+function useGetInfiniteReviewFormAnswer(
+  reviewFormCode: string,
+  display?: DisplayModeType,
+  queryOptions?: any,
 ) {
-  return useQuery<ReviewFormAnswerList, ErrorResponse>(
-    [QUERY_KEY.DATA.REVIEW, QUERY_KEY.API.GET_REVIEWS, { reviewFormCode, display }],
-    () => reviewAPI.getFormAnswer(reviewFormCode, display),
+  const fetchFunc = async ({ pageParam = 1 }) => {
+    const data = await reviewAPI.getFormAnswer(
+      String(pageParam),
+      PAGE_OPTION.REVIEW_ITEM_SIZE,
+      reviewFormCode,
+      display,
+    );
+
+    return {
+      data,
+      currentPage: pageParam,
+    };
+  };
+
+  return useInfiniteQuery<InfiniteItem<ReviewFormAnswerList>>(
+    [QUERY_KEY.DATA.REVIEW, QUERY_KEY.API.GET_REVIEW_PUBLIC_ANSWER, { display }],
+    fetchFunc,
     {
+      getNextPageParam: (lastItem) =>
+        lastItem.data.isLastPage ? undefined : lastItem.currentPage + 1,
       ...queryOptions,
     },
   );
@@ -84,7 +97,7 @@ function useGetInfiniteReviewPublicAnswer(filter: TimelineFilterType, queryOptio
 
 export {
   useGetReviewForm,
-  useGetReviewFormAnswer,
   useGetReviewAnswer,
   useGetInfiniteReviewPublicAnswer,
+  useGetInfiniteReviewFormAnswer,
 };

--- a/frontend/src/service/@shared/hooks/queries/review/useGet.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useGet.ts
@@ -9,6 +9,7 @@ import {
   ReviewForm,
   ReviewFormAnswerList,
   ReviewPublicAnswerList,
+  TimelineFilterType,
 } from 'types';
 import 'types';
 
@@ -56,9 +57,13 @@ function useGetReviewFormAnswer(
   );
 }
 
-function useGetInfiniteReviewPublicAnswer(queryOptions?: any) {
+function useGetInfiniteReviewPublicAnswer(filter: TimelineFilterType, queryOptions?: any) {
   const fetchFunc = async ({ pageParam = 1 }) => {
-    const data = await reviewAPI.getPublicAnswer(String(pageParam), PAGE_OPTION.REVIEW_ITEM_SIZE);
+    const data = await reviewAPI.getPublicAnswer(
+      String(pageParam),
+      PAGE_OPTION.REVIEW_ITEM_SIZE,
+      filter,
+    );
 
     return {
       data,
@@ -67,7 +72,7 @@ function useGetInfiniteReviewPublicAnswer(queryOptions?: any) {
   };
 
   return useInfiniteQuery<InfiniteItem<ReviewPublicAnswerList>>(
-    [QUERY_KEY.DATA.REVIEW, QUERY_KEY.API.GET_REVIEW_PUBLIC_ANSWER],
+    [QUERY_KEY.DATA.REVIEW, QUERY_KEY.API.GET_REVIEW_PUBLIC_ANSWER, { filter }],
     fetchFunc,
     {
       getNextPageParam: (lastItem) =>

--- a/frontend/src/service/@shared/layout/MainLayout/Header.tsx
+++ b/frontend/src/service/@shared/layout/MainLayout/Header.tsx
@@ -1,5 +1,13 @@
 import { Link } from 'react-router-dom';
 
+import {
+  faPenToSquare,
+  faRightFromBracket,
+  faSearch,
+  faUser,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import cn from 'classnames';
 import { GITHUB_OAUTH_LOGIN_URL, MODAL_LIST, PAGE_LIST } from 'constant';
 
@@ -11,14 +19,6 @@ import { Button, Logo, Text, TextBox, PopupBox } from 'common/components';
 import imageDefaultProfile from 'assets/images/profile.png';
 
 import styles from './styles.module.scss';
-
-import {
-  faPenToSquare,
-  faRightFromBracket,
-  faSearch,
-  faUser,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 function Header() {
   const { isLogin, getUserProfileQuery } = useAuth();
@@ -42,7 +42,9 @@ function Header() {
 
         <div className={styles.navItemContainer}>
           <TextBox placeholder="검색어를 입력해주세요." />
-          <FontAwesomeIcon className={styles.searchIcon} icon={faSearch} />
+          <Link to="/pending">
+            <FontAwesomeIcon className={styles.searchIcon} icon={faSearch} />
+          </Link>
         </div>
 
         <ul className={styles.menuList}>

--- a/frontend/src/service/@shared/layout/MainLayout/styles.module.scss
+++ b/frontend/src/service/@shared/layout/MainLayout/styles.module.scss
@@ -46,8 +46,10 @@
   position: absolute;
   top: 50%;
   right: 1rem;
+  color: $THEME_COLOR_THEME_TEXT_800;
 
   transform: translateY(-50%);
+  cursor: pointer;
 }
 
 .menu-list {

--- a/frontend/src/service/@shared/validator/common.ts
+++ b/frontend/src/service/@shared/validator/common.ts
@@ -1,0 +1,7 @@
+function validateTab(validTabNameArray: string[], currentTab: string) {
+  if (validTabNameArray.findIndex((tab) => tab === currentTab) < 0) {
+    throw new Error('찾을 수 없는 페이지입니다.');
+  }
+}
+
+export { validateTab };

--- a/frontend/src/service/@shared/validator/common.ts
+++ b/frontend/src/service/@shared/validator/common.ts
@@ -1,7 +1,7 @@
-function validateTab(validTabNameArray: string[], currentTab: string) {
+function validateFilter(validTabNameArray: string[], currentTab: string) {
   if (validTabNameArray.findIndex((tab) => tab === currentTab) < 0) {
     throw new Error('찾을 수 없는 페이지입니다.');
   }
 }
 
-export { validateTab };
+export { validateFilter };

--- a/frontend/src/service/@shared/validator/index.ts
+++ b/frontend/src/service/@shared/validator/index.ts
@@ -1,3 +1,4 @@
 export * from './auth';
 export * from './review';
 export * from './user';
+export * from './common';

--- a/frontend/src/service/@shared/validator/user.ts
+++ b/frontend/src/service/@shared/validator/user.ts
@@ -6,10 +6,4 @@ function validateNickname(nickname: string) {
   }
 }
 
-function validateTab(currentTab: string) {
-  if (['reviews', 'review-forms', 'templates'].findIndex((tab) => tab === currentTab) < 0) {
-    throw new Error('찾을 수 없는 페이지입니다.');
-  }
-}
-
-export { validateNickname, validateTab };
+export { validateNickname };

--- a/frontend/src/service/review/pages/ReviewOverviewPage/useOverviewQueries.ts
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/useOverviewQueries.ts
@@ -1,9 +1,0 @@
-import { GetReviewFormAnswerResponse, ReviewForm } from 'types';
-
-import { useGetReviewForm, useGetReviewFormAnswer } from 'service/@shared/hooks/queries/review';
-
-function useOverviewQueries(reviewFormCode = '') {
-  return {};
-}
-
-export default useOverviewQueries;

--- a/frontend/src/service/review/pages/ReviewOverviewPage/views/ListView/index.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/views/ListView/index.tsx
@@ -1,5 +1,10 @@
-import { useRef } from 'react';
+import { ForwardedRef, forwardRef, useRef } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
+
+import { faCircleCheck } from '@fortawesome/free-regular-svg-icons';
+import { faPenToSquare, faRightToBracket, faShareNodes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
 import { PAGE_LIST } from 'constant';
@@ -7,15 +12,11 @@ import { ReviewFormAnswer } from 'types';
 
 import useSnackbar from 'common/hooks/useSnackbar';
 
-import { Text, FlexContainer, Button, TextBox } from 'common/components';
+import { Text, FlexContainer, Button, TextBox, Skeleton } from 'common/components';
 
 import ScrollPanel from 'common/components/ScrollPanel';
 
 import styles from './styles.module.scss';
-
-import { faCircleCheck } from '@fortawesome/free-regular-svg-icons';
-import { faPenToSquare, faRightToBracket, faShareNodes } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 interface ContainerProps {
   children: React.ReactNode;
@@ -59,9 +60,17 @@ interface ReviewProps {
   children: React.ReactNode;
 }
 
-const Review = ({ children }: ReviewProps) => {
-  return <section className={cn(styles.cardBox, styles.reviewContainer)}>{children}</section>;
-};
+const Review = React.memo(
+  forwardRef(({ children }: ReviewProps, forwardedRef: ForwardedRef<HTMLElement>) => {
+    return (
+      <section className={cn(styles.cardBox, styles.reviewContainer)} ref={forwardedRef}>
+        {children}
+      </section>
+    );
+  }),
+);
+
+Review.displayName = 'Review';
 
 interface SideMenuProps {
   isLoading: boolean;
@@ -220,6 +229,22 @@ const ReviewShortcut = ({ id, info }: ReviewFormAnswer) => {
   );
 };
 
+interface LoadingProps {
+  line: number;
+}
+
+const Loading = ({ line }: LoadingProps) => {
+  return (
+    <>
+      {Array.from({ length: line }, (_, index) => (
+        <ListView.Review key={index}>
+          <Skeleton />
+        </ListView.Review>
+      ))}
+    </>
+  );
+};
+
 export const ListView = Object.assign(Container, {
   Content,
   ParticipantList,
@@ -232,4 +257,5 @@ export const ListView = Object.assign(Container, {
   FormManageButtons,
   ReviewShortcutList,
   ReviewShortcut,
+  Loading,
 });

--- a/frontend/src/service/review/pages/ReviewOverviewPage/views/SheetView/index.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/views/SheetView/index.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { ForwardedRef, forwardRef } from 'react';
+
+import { Skeleton } from 'common/components';
 
 import Profile from 'service/@shared/components/Profile';
 
@@ -39,9 +41,13 @@ interface AnswersProps {
   children?: React.ReactNode;
 }
 
-const Answers = ({ children }: AnswersProps) => {
-  return <tr>{children}</tr>;
-};
+const Answers = React.memo(
+  forwardRef(({ children }: AnswersProps, forwardedRef: ForwardedRef<HTMLTableRowElement>) => {
+    return <tr ref={forwardedRef}>{children}</tr>;
+  }),
+);
+
+Answers.displayName = 'Answers';
 
 interface CreatorProps {
   socialId: number;
@@ -69,10 +75,32 @@ const Item = ({ isTitle, children }: ItemProps) => {
   return React.createElement(isTitle ? 'th' : 'td', null, children);
 };
 
+interface LoadingProps {
+  line: number;
+}
+
+const Loading = ({ line }: LoadingProps) => {
+  return (
+    <>
+      {Array.from({ length: line }, (_, index) => (
+        <SheetView.Answers key={index}>
+          <td>
+            <Skeleton />
+          </td>
+          <td>
+            <Skeleton />
+          </td>
+        </SheetView.Answers>
+      ))}
+    </>
+  );
+};
+
 export const SheetView = Object.assign(Container, {
   ReviewList,
   Questions,
   Answers,
   Creator,
   Item,
+  Loading,
 });

--- a/frontend/src/service/review/pages/ReviewTimelinePage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/index.tsx
@@ -1,10 +1,10 @@
 import React, { useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { faArrowTrendUp, faHeart, faPenNib } from '@fortawesome/free-solid-svg-icons';
+import { faArrowTrendUp, faPenNib } from '@fortawesome/free-solid-svg-icons';
 
-import { PAGE_LIST, PAGE_OPTION, QUERY_KEY } from 'constant';
-import { ReviewPublicAnswer, ReviewPublicAnswerList } from 'types';
+import { PAGE_LIST, PAGE_OPTION, QUERY_KEY, TAB } from 'constant';
+import { ReviewPublicAnswer, ReviewPublicAnswerList, TimelineFilterType } from 'types';
 
 import useSnackbar from 'common/hooks/useSnackbar';
 import useStackFetch from 'common/hooks/useStackFetch';
@@ -23,12 +23,18 @@ import Feed from './views/Feed';
 import SideMenu from './views/SideMenu';
 import queryClient from 'api/config/queryClient';
 import { updateReviewLike } from 'api/review.api';
+import { validateTab } from 'service/@shared/validator';
 
 type ReviewId = ReviewPublicAnswer['id'];
 
 function ReviewTimelinePage() {
+  const [searchParam] = useSearchParams();
+
+  const currentTab = searchParam.get('filter') || 'trend';
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
+
+  validateTab(['trend', 'latest'], currentTab);
 
   const { mutate: reviewAnswerDelete } = useDeleteReviewAnswer();
   const { addFetch } = useStackFetch(2000);
@@ -39,7 +45,7 @@ function ReviewTimelinePage() {
     isError,
     fetchNextPage,
     isFetching,
-  } = useGetInfiniteReviewPublicAnswer();
+  } = useGetInfiniteReviewPublicAnswer(currentTab as TimelineFilterType);
 
   const reviewsLikeStack = useRef<Record<ReviewId, number>>({});
 
@@ -123,12 +129,24 @@ function ReviewTimelinePage() {
         <SideMenu.Title>탐색하기</SideMenu.Title>
 
         <SideMenu.List>
-          <SideMenu.Menu icon={faArrowTrendUp}>트랜딩</SideMenu.Menu>
-          <SideMenu.Menu icon={faPenNib}>최신글</SideMenu.Menu>
-          <SideMenu.Menu icon={faHeart}>구독</SideMenu.Menu>
+          <SideMenu.Menu
+            isCurrentTab={currentTab === TAB.TIMELINE.TREND}
+            filter={TAB.TIMELINE.TREND as TimelineFilterType}
+            icon={faArrowTrendUp}
+          >
+            트랜딩
+          </SideMenu.Menu>
+          <SideMenu.Menu
+            isCurrentTab={currentTab === TAB.TIMELINE.LATEST}
+            filter={TAB.TIMELINE.LATEST as TimelineFilterType}
+            icon={faPenNib}
+          >
+            최신글
+          </SideMenu.Menu>
+          {/* <SideMenu.Menu icon={faHeart}>구독</SideMenu.Menu> */}
         </SideMenu.List>
 
-        <SideMenu.Title>나의 구독</SideMenu.Title>
+        {/* <SideMenu.Title>나의 구독</SideMenu.Title> */}
       </SideMenu>
 
       <Feed>

--- a/frontend/src/service/review/pages/ReviewTimelinePage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/index.tsx
@@ -4,7 +4,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { faArrowTrendUp, faPenNib } from '@fortawesome/free-solid-svg-icons';
 import { InfiniteData } from '@tanstack/react-query';
 
-import { PAGE_LIST, PAGE_OPTION, QUERY_KEY, TAB } from 'constant';
+import { PAGE_LIST, PAGE_OPTION, QUERY_KEY, FILTER } from 'constant';
 import {
   InfiniteItem,
   ReviewPublicAnswer,
@@ -29,7 +29,7 @@ import Feed from './views/Feed';
 import SideMenu from './views/SideMenu';
 import queryClient from 'api/config/queryClient';
 import { updateReviewLike } from 'api/review.api';
-import { validateTab } from 'service/@shared/validator';
+import { validateFilter } from 'service/@shared/validator';
 
 type ReviewId = ReviewPublicAnswer['id'];
 
@@ -40,7 +40,7 @@ function ReviewTimelinePage() {
   const navigate = useNavigate();
   const { showSnackbar } = useSnackbar();
 
-  validateTab(['trend', 'latest'], currentTab);
+  validateFilter([FILTER.TIMELINE_TAB.TREND, FILTER.TIMELINE_TAB.LATEST], currentTab);
 
   const { mutate: reviewAnswerDelete } = useDeleteReviewAnswer();
   const { addFetch } = useStackFetch(2000);
@@ -58,7 +58,7 @@ function ReviewTimelinePage() {
   const { targetRef } = useIntersectionObserver<ReviewPublicAnswerList, HTMLDivElement>(
     fetchNextPage,
     { threshold: 0.75 },
-    reviews,
+    [reviews],
   );
 
   if (isError || isLoading) return <>{/* Error Boundary, Suspense Used */}</>;
@@ -144,15 +144,15 @@ function ReviewTimelinePage() {
 
         <SideMenu.List>
           <SideMenu.Menu
-            isCurrentTab={currentTab === TAB.TIMELINE.TREND}
-            filter={TAB.TIMELINE.TREND as TimelineFilterType}
+            isCurrentTab={currentTab === FILTER.TIMELINE_TAB.TREND}
+            filter={FILTER.TIMELINE_TAB.TREND as TimelineFilterType}
             icon={faArrowTrendUp}
           >
             트랜딩
           </SideMenu.Menu>
           <SideMenu.Menu
-            isCurrentTab={currentTab === TAB.TIMELINE.LATEST}
-            filter={TAB.TIMELINE.LATEST as TimelineFilterType}
+            isCurrentTab={currentTab === FILTER.TIMELINE_TAB.LATEST}
+            filter={FILTER.TIMELINE_TAB.LATEST as TimelineFilterType}
             icon={faPenNib}
           >
             최신글

--- a/frontend/src/service/review/pages/ReviewTimelinePage/useIntersectionObserver.ts
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/useIntersectionObserver.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  FetchNextPageOptions,
+  InfiniteData,
+  InfiniteQueryObserverResult,
+} from '@tanstack/react-query';
+
+import { InfiniteItem } from 'types';
+
+interface ObserverOptionType {
+  root?: HTMLDivElement;
+  rootMargin?: string;
+  threshold: number;
+}
+
+function useIntersectionObserver<DataType, RefElementType extends Element>(
+  onIntersect: (
+    options?: FetchNextPageOptions,
+  ) => Promise<InfiniteQueryObserverResult<InfiniteItem<DataType>>>,
+  option: ObserverOptionType,
+  data: InfiniteData<InfiniteItem<DataType>> | undefined,
+) {
+  const targetRef = useRef<RefElementType>(null);
+
+  useEffect(() => {
+    if (!targetRef || !targetRef.current) {
+      return;
+    }
+    const target = targetRef.current;
+    const handleIntersect: IntersectionObserverCallback = ([entry]) => {
+      if (entry.isIntersecting) {
+        onIntersect();
+      }
+    };
+    const observer = new IntersectionObserver(handleIntersect, option);
+
+    observer.observe(target);
+
+    return () => {
+      if (targetRef && target) {
+        observer.disconnect();
+      }
+    };
+  }, [data]);
+
+  return { targetRef };
+}
+
+export default useIntersectionObserver;

--- a/frontend/src/service/review/pages/ReviewTimelinePage/useIntersectionObserver.ts
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/useIntersectionObserver.ts
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import {
-  FetchNextPageOptions,
-  InfiniteData,
-  InfiniteQueryObserverResult,
-} from '@tanstack/react-query';
+import { FetchNextPageOptions, InfiniteQueryObserverResult } from '@tanstack/react-query';
 
 import { InfiniteItem } from 'types';
 
@@ -19,7 +15,7 @@ function useIntersectionObserver<DataType, RefElementType extends Element>(
     options?: FetchNextPageOptions,
   ) => Promise<InfiniteQueryObserverResult<InfiniteItem<DataType>>>,
   option: ObserverOptionType,
-  data: InfiniteData<InfiniteItem<DataType>> | undefined,
+  dependArray: unknown[],
 ) {
   const targetRef = useRef<RefElementType>(null);
 
@@ -28,6 +24,7 @@ function useIntersectionObserver<DataType, RefElementType extends Element>(
       return;
     }
     const target = targetRef.current;
+
     const handleIntersect: IntersectionObserverCallback = ([entry]) => {
       if (entry.isIntersecting) {
         onIntersect();
@@ -42,7 +39,7 @@ function useIntersectionObserver<DataType, RefElementType extends Element>(
         observer.disconnect();
       }
     };
-  }, [data]);
+  }, dependArray);
 
   return { targetRef };
 }

--- a/frontend/src/service/review/pages/ReviewTimelinePage/views/Feed/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/views/Feed/index.tsx
@@ -1,4 +1,6 @@
-import { FlexContainer, Text } from 'common/components';
+import React, { ForwardedRef, forwardRef } from 'react';
+
+import { FlexContainer, Skeleton, Text } from 'common/components';
 
 import Profile from 'service/@shared/components/Profile';
 
@@ -37,16 +39,21 @@ function List({ children }: ListProps) {
 }
 
 interface ReviewAnswerProps {
+  isLoading: boolean;
   children: React.ReactNode;
 }
 
-function ReviewAnswer({ children }: ReviewAnswerProps) {
-  return (
-    <FlexContainer className={styles.reviewAnswer} gap="medium">
-      {children}
-    </FlexContainer>
-  );
-}
+const ReviewAnswer = forwardRef(
+  ({ isLoading, children }: ReviewAnswerProps, forwardedRef: ForwardedRef<HTMLDivElement>) => {
+    return (
+      <div className={styles.reviewAnswer} ref={forwardedRef}>
+        {isLoading ? <Skeleton /> : children}
+      </div>
+    );
+  },
+);
+
+ReviewAnswer.displayName = 'ReviewAnswer';
 
 interface UserProfileProps {
   socialId: number;

--- a/frontend/src/service/review/pages/ReviewTimelinePage/views/Feed/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/views/Feed/index.tsx
@@ -43,14 +43,16 @@ interface ReviewAnswerProps {
   children: React.ReactNode;
 }
 
-const ReviewAnswer = forwardRef(
-  ({ isLoading, children }: ReviewAnswerProps, forwardedRef: ForwardedRef<HTMLDivElement>) => {
-    return (
-      <div className={styles.reviewAnswer} ref={forwardedRef}>
-        {isLoading ? <Skeleton /> : children}
-      </div>
-    );
-  },
+const ReviewAnswer = React.memo(
+  forwardRef(
+    ({ isLoading, children }: ReviewAnswerProps, forwardedRef: ForwardedRef<HTMLDivElement>) => {
+      return (
+        <div className={styles.reviewAnswer} ref={forwardedRef}>
+          {isLoading ? <Skeleton /> : children}
+        </div>
+      );
+    },
+  ),
 );
 
 ReviewAnswer.displayName = 'ReviewAnswer';

--- a/frontend/src/service/review/pages/ReviewTimelinePage/views/Feed/styles.module.scss
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/views/Feed/styles.module.scss
@@ -7,6 +7,10 @@
   }
 
   .review-answer {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
     position: relative;
     padding: 1.5rem;
 

--- a/frontend/src/service/review/pages/ReviewTimelinePage/views/SideMenu/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/views/SideMenu/index.tsx
@@ -1,9 +1,15 @@
-import { FlexContainer, Text } from 'common/components';
-
-import styles from './styles.module.scss';
+import { Link } from 'react-router-dom';
 
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+import cn from 'classnames';
+import { PAGE_LIST } from 'constant';
+import { TimelineFilterType } from 'types';
+
+import { FlexContainer, Text } from 'common/components';
+
+import styles from './styles.module.scss';
 
 interface ContainerProps {
   children: React.ReactNode;
@@ -42,15 +48,19 @@ function List({ children }: ListProps) {
 }
 
 interface MenuProps {
+  isCurrentTab: boolean;
+  filter: TimelineFilterType;
   icon: IconDefinition;
   children: string;
 }
 
-function Menu({ icon, children }: MenuProps) {
+function Menu({ isCurrentTab, filter, icon, children }: MenuProps) {
   return (
-    <li className={styles.menu}>
-      <FontAwesomeIcon icon={icon} /> {children}
-    </li>
+    <Link to={`${PAGE_LIST.TIMELINE}?filter=${filter}`}>
+      <li className={cn(styles.menu, { [styles.focus]: isCurrentTab })}>
+        <FontAwesomeIcon icon={icon} /> {children}
+      </li>
+    </Link>
   );
 }
 

--- a/frontend/src/service/review/pages/ReviewTimelinePage/views/SideMenu/styles.module.scss
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/views/SideMenu/styles.module.scss
@@ -37,6 +37,16 @@
       }
     }
 
+    .focus {
+      font-weight: bold;
+      font-size: 1.1rem;
+      color: $THEME_COLOR_THEME_TEXT_800;
+
+      svg {
+        color: $THEME_COLOR_STATUS_PRIMARY_500;
+      }
+    }
+
     .menu:hover {
       transform: translateX(3%);
       color: $THEME_COLOR_STATUS_PRIMARY_600;

--- a/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
@@ -13,7 +13,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { GITHUB_PROFILE_URL, PAGE_LIST, TEMPLATE_TAB } from 'constant';
+import { GITHUB_PROFILE_URL, PAGE_LIST, TAB } from 'constant';
 
 import useSnackbar from 'common/hooks/useSnackbar';
 
@@ -205,7 +205,7 @@ function TemplateDetailPage() {
                 <span>새 템플릿 작성</span>
               </Button>
             </Link>
-            <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TEMPLATE_TAB.TREND}`}>
+            <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TAB.TEMPLATE.TREND}`}>
               <Button size="medium" theme="outlined">
                 <FontAwesomeIcon icon={faList} />
                 <span>목록</span>

--- a/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
@@ -13,7 +13,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { GITHUB_PROFILE_URL, PAGE_LIST, TAB } from 'constant';
+import { GITHUB_PROFILE_URL, PAGE_LIST, FILTER } from 'constant';
 
 import useSnackbar from 'common/hooks/useSnackbar';
 
@@ -205,7 +205,7 @@ function TemplateDetailPage() {
                 <span>새 템플릿 작성</span>
               </Button>
             </Link>
-            <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TAB.TEMPLATE.TREND}`}>
+            <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${FILTER.TEMPLATE_TAB.TREND}`}>
               <Button size="medium" theme="outlined">
                 <FontAwesomeIcon icon={faList} />
                 <span>목록</span>

--- a/frontend/src/service/template/pages/TemplateDetailPage/useTemplateDetailQueries.ts
+++ b/frontend/src/service/template/pages/TemplateDetailPage/useTemplateDetailQueries.ts
@@ -1,4 +1,4 @@
-import { PAGE_OPTION, TAB } from 'constant';
+import { PAGE_OPTION, FILTER } from 'constant';
 import { TemplateFilterType } from 'types';
 
 import { useGetTemplate, useGetTemplates } from 'service/@shared/hooks/queries/template';
@@ -13,7 +13,7 @@ function useTemplateDetailQueries(templateId: number) {
     isError: isTemplatesError,
     error: templatesError,
   } = useGetTemplates(
-    TAB.TEMPLATE.TREND as TemplateFilterType,
+    FILTER.TEMPLATE_TAB.TREND as TemplateFilterType,
     String(1),
     PAGE_OPTION.TEMPLATE_TREND_ITEM_SIZE,
   );

--- a/frontend/src/service/template/pages/TemplateDetailPage/useTemplateDetailQueries.ts
+++ b/frontend/src/service/template/pages/TemplateDetailPage/useTemplateDetailQueries.ts
@@ -1,4 +1,4 @@
-import { PAGE_OPTION, TEMPLATE_TAB } from 'constant';
+import { PAGE_OPTION, TAB } from 'constant';
 import { TemplateFilterType } from 'types';
 
 import { useGetTemplate, useGetTemplates } from 'service/@shared/hooks/queries/template';
@@ -13,7 +13,7 @@ function useTemplateDetailQueries(templateId: number) {
     isError: isTemplatesError,
     error: templatesError,
   } = useGetTemplates(
-    TEMPLATE_TAB.TREND as TemplateFilterType,
+    TAB.TEMPLATE.TREND as TemplateFilterType,
     String(1),
     PAGE_OPTION.TEMPLATE_TREND_ITEM_SIZE,
   );

--- a/frontend/src/service/template/pages/TemplateListPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateListPage/index.tsx
@@ -4,7 +4,7 @@ import { faArrowUp, faBarsStaggered, faPenToSquare } from '@fortawesome/free-sol
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { PAGE_LIST, TEMPLATE_TAB } from 'constant';
+import { PAGE_LIST, TAB } from 'constant';
 import { TemplateFilterType } from 'types';
 
 import { useGetTemplates } from 'service/@shared/hooks/queries/template/useGet';
@@ -16,12 +16,15 @@ import LayoutContainer from 'service/@shared/components/LayoutContainer';
 import styles from './styles.module.scss';
 
 import TemplateListContainer from './TemplateListContainer';
+import { validateTab } from 'service/@shared/validator';
 
 function TemplateListPage() {
   const [searchParam] = useSearchParams();
 
   const currentTab = searchParam.get('filter') || 'trend';
   const pageNumber = searchParam.get('page') || String(1);
+
+  validateTab(['trend', 'latest'], currentTab);
 
   const initialTemplates = {
     numberOfTemplates: 0,
@@ -35,11 +38,11 @@ function TemplateListPage() {
     <LayoutContainer>
       <FlexContainer className={styles.header} direction="row" justify="space-between">
         <FlexContainer direction="row">
-          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TEMPLATE_TAB.TREND}`}>
+          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TAB.TEMPLATE.TREND}`}>
             <button className={styles.button}>
               <div
                 className={cn(styles.buttonBox, {
-                  [styles.focus]: currentTab === TEMPLATE_TAB.TREND,
+                  [styles.focus]: currentTab === TAB.TEMPLATE.TREND,
                 })}
               >
                 <FontAwesomeIcon className={styles.icon} icon={faArrowUp} />
@@ -47,11 +50,11 @@ function TemplateListPage() {
               </div>
             </button>
           </Link>
-          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TEMPLATE_TAB.LATEST}`}>
+          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TAB.TEMPLATE.LATEST}`}>
             <button className={styles.button}>
               <div
                 className={cn(styles.buttonBox, {
-                  [styles.focus]: currentTab === TEMPLATE_TAB.LATEST,
+                  [styles.focus]: currentTab === TAB.TEMPLATE.LATEST,
                 })}
               >
                 <FontAwesomeIcon className={styles.icon} icon={faBarsStaggered} />

--- a/frontend/src/service/template/pages/TemplateListPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateListPage/index.tsx
@@ -4,7 +4,7 @@ import { faArrowUp, faBarsStaggered, faPenToSquare } from '@fortawesome/free-sol
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { PAGE_LIST, TAB } from 'constant';
+import { PAGE_LIST, FILTER } from 'constant';
 import { TemplateFilterType } from 'types';
 
 import { useGetTemplates } from 'service/@shared/hooks/queries/template/useGet';
@@ -16,15 +16,15 @@ import LayoutContainer from 'service/@shared/components/LayoutContainer';
 import styles from './styles.module.scss';
 
 import TemplateListContainer from './TemplateListContainer';
-import { validateTab } from 'service/@shared/validator';
+import { validateFilter } from 'service/@shared/validator';
 
 function TemplateListPage() {
   const [searchParam] = useSearchParams();
 
-  const currentTab = searchParam.get('filter') || 'trend';
+  const currentTab = searchParam.get('filter') || FILTER.TEMPLATE_TAB.TREND;
   const pageNumber = searchParam.get('page') || String(1);
 
-  validateTab(['trend', 'latest'], currentTab);
+  validateFilter([FILTER.TEMPLATE_TAB.TREND, FILTER.TEMPLATE_TAB.LATEST], currentTab);
 
   const initialTemplates = {
     numberOfTemplates: 0,
@@ -38,11 +38,11 @@ function TemplateListPage() {
     <LayoutContainer>
       <FlexContainer className={styles.header} direction="row" justify="space-between">
         <FlexContainer direction="row">
-          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TAB.TEMPLATE.TREND}`}>
+          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${FILTER.TEMPLATE_TAB.TREND}`}>
             <button className={styles.button}>
               <div
                 className={cn(styles.buttonBox, {
-                  [styles.focus]: currentTab === TAB.TEMPLATE.TREND,
+                  [styles.focus]: currentTab === FILTER.TEMPLATE_TAB.TREND,
                 })}
               >
                 <FontAwesomeIcon className={styles.icon} icon={faArrowUp} />
@@ -50,11 +50,11 @@ function TemplateListPage() {
               </div>
             </button>
           </Link>
-          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${TAB.TEMPLATE.LATEST}`}>
+          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?filter=${FILTER.TEMPLATE_TAB.LATEST}`}>
             <button className={styles.button}>
               <div
                 className={cn(styles.buttonBox, {
-                  [styles.focus]: currentTab === TAB.TEMPLATE.LATEST,
+                  [styles.focus]: currentTab === FILTER.TEMPLATE_TAB.LATEST,
                 })}
               >
                 <FontAwesomeIcon className={styles.icon} icon={faBarsStaggered} />

--- a/frontend/src/service/user/pages/MainPage/index.tsx
+++ b/frontend/src/service/user/pages/MainPage/index.tsx
@@ -1,7 +1,10 @@
 import { useEffect } from 'react';
 
+import { faPenToSquare } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
 import cn from 'classnames';
-import { MODAL_LIST, PAGE_OPTION, TEMPLATE_TAB } from 'constant';
+import { MODAL_LIST, PAGE_OPTION, TAB } from 'constant';
 import { PAGE_LIST } from 'constant';
 import { TemplateFilterType } from 'types';
 
@@ -18,16 +21,13 @@ import TemplateCard from 'service/template/components/TemplateCard';
 
 import styles from './styles.module.scss';
 
-import { faPenToSquare } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-
 function MainPage() {
   const { showModal } = useModal();
   const onClickReviewStart = () => {
     showModal(MODAL_LIST.REVIEW_START);
   };
   const { data, isError, error } = useGetTemplates(
-    TEMPLATE_TAB.TREND as TemplateFilterType,
+    TAB.TEMPLATE.TREND as TemplateFilterType,
     String(1),
     PAGE_OPTION.TEMPLATE_TREND_ITEM_SIZE,
   );

--- a/frontend/src/service/user/pages/MainPage/index.tsx
+++ b/frontend/src/service/user/pages/MainPage/index.tsx
@@ -4,7 +4,7 @@ import { faPenToSquare } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { MODAL_LIST, PAGE_OPTION, TAB } from 'constant';
+import { MODAL_LIST, PAGE_OPTION, FILTER } from 'constant';
 import { PAGE_LIST } from 'constant';
 import { TemplateFilterType } from 'types';
 
@@ -27,7 +27,7 @@ function MainPage() {
     showModal(MODAL_LIST.REVIEW_START);
   };
   const { data, isError, error } = useGetTemplates(
-    TAB.TEMPLATE.TREND as TemplateFilterType,
+    FILTER.TEMPLATE_TAB.TREND as TemplateFilterType,
     String(1),
     PAGE_OPTION.TEMPLATE_TREND_ITEM_SIZE,
   );

--- a/frontend/src/service/user/pages/ProfilePage/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/index.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { faEraser } from '@fortawesome/free-solid-svg-icons';
 
-import { TAB, PAGE_LIST, MODAL_LIST, PAGE_OPTION } from 'constant';
+import { FILTER, PAGE_LIST, MODAL_LIST, PAGE_OPTION } from 'constant';
 import { Tabs } from 'types';
 
 import useModal from 'common/hooks/useModal';
@@ -19,7 +19,7 @@ import styles from './styles.module.scss';
 import useProfilePageQueries from './useProfilePageQueries';
 import { ArticleList } from './view/ArticleList';
 import { Controller } from './view/Controller';
-import { validateTab } from 'service/@shared/validator';
+import { validateFilter } from 'service/@shared/validator';
 
 function ProfilePage() {
   const navigate = useNavigate();
@@ -29,10 +29,17 @@ function ProfilePage() {
   const { showModal } = useModal();
   const { showSnackbar } = useSnackbar();
 
-  const currentTab = searchParams.get('tab') || TAB.USER_PROFILE.REVIEWS;
+  const currentTab = searchParams.get('tab') || FILTER.USER_PROFILE_TAB.REVIEWS;
   const pageNumber = searchParams.get('page') || String(1);
 
-  validateTab(['reviews', 'review-forms', 'templates'], currentTab);
+  validateFilter(
+    [
+      FILTER.USER_PROFILE_TAB.REVIEWS,
+      FILTER.USER_PROFILE_TAB.REVIEW_FORMS,
+      FILTER.USER_PROFILE_TAB.TEMPLATES,
+    ],
+    currentTab,
+  );
 
   const queries = useProfilePageQueries(currentTab as Tabs, socialId, pageNumber);
   if (!queries) return <>{/* Error Boundary, Suspense Used */}</>;
@@ -46,9 +53,9 @@ function ProfilePage() {
   } = queries;
 
   const subjectTitle = {
-    [TAB.USER_PROFILE.REVIEWS]: '작성한 회고',
-    [TAB.USER_PROFILE.REVIEW_FORMS]: '생성한 질문지',
-    [TAB.USER_PROFILE.TEMPLATES]: '생성한 템플릿',
+    [FILTER.USER_PROFILE_TAB.REVIEWS]: '작성한 회고',
+    [FILTER.USER_PROFILE_TAB.REVIEW_FORMS]: '생성한 질문지',
+    [FILTER.USER_PROFILE_TAB.TEMPLATES]: '생성한 템플릿',
   };
 
   const handleChangeTab = (filter: string) => () => {
@@ -88,19 +95,19 @@ function ProfilePage() {
         )}를(을) 삭제하시겠습니까?\n취소 후 복구를 할 수 없습니다.`,
       )
     ) {
-      if (currentTab === TAB.USER_PROFILE.REVIEWS) {
+      if (currentTab === FILTER.USER_PROFILE_TAB.REVIEWS) {
         deleteReviewMutation.mutate(index as number, {
           onSuccess: deleteSuccessOption,
           onError: ({ message }) => alert(message),
         });
       }
-      if (currentTab === TAB.USER_PROFILE.REVIEW_FORMS) {
+      if (currentTab === FILTER.USER_PROFILE_TAB.REVIEW_FORMS) {
         deleteReviewFormMutation.mutate(index as string, {
           onSuccess: deleteSuccessOption,
           onError: ({ message }) => alert(message),
         });
       }
-      if (currentTab === TAB.USER_PROFILE.TEMPLATES) {
+      if (currentTab === FILTER.USER_PROFILE_TAB.TEMPLATES) {
         deleteTemplateMutation.mutate(index as number, {
           onSuccess: deleteSuccessOption,
           onError: ({ message }) => alert(message),

--- a/frontend/src/service/user/pages/ProfilePage/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/index.tsx
@@ -2,7 +2,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { faEraser } from '@fortawesome/free-solid-svg-icons';
 
-import { USER_PROFILE_TAB, PAGE_LIST, MODAL_LIST, PAGE_OPTION } from 'constant';
+import { TAB, PAGE_LIST, MODAL_LIST, PAGE_OPTION } from 'constant';
 import { Tabs } from 'types';
 
 import useModal from 'common/hooks/useModal';
@@ -29,10 +29,10 @@ function ProfilePage() {
   const { showModal } = useModal();
   const { showSnackbar } = useSnackbar();
 
-  const currentTab = searchParams.get('tab') || USER_PROFILE_TAB.REVIEWS;
+  const currentTab = searchParams.get('tab') || TAB.USER_PROFILE.REVIEWS;
   const pageNumber = searchParams.get('page') || String(1);
 
-  validateTab(currentTab);
+  validateTab(['reviews', 'review-forms', 'templates'], currentTab);
 
   const queries = useProfilePageQueries(currentTab as Tabs, socialId, pageNumber);
   if (!queries) return <>{/* Error Boundary, Suspense Used */}</>;
@@ -46,9 +46,9 @@ function ProfilePage() {
   } = queries;
 
   const subjectTitle = {
-    [USER_PROFILE_TAB.REVIEWS]: '작성한 회고',
-    [USER_PROFILE_TAB.REVIEW_FORMS]: '생성한 질문지',
-    [USER_PROFILE_TAB.TEMPLATES]: '생성한 템플릿',
+    [TAB.USER_PROFILE.REVIEWS]: '작성한 회고',
+    [TAB.USER_PROFILE.REVIEW_FORMS]: '생성한 질문지',
+    [TAB.USER_PROFILE.TEMPLATES]: '생성한 템플릿',
   };
 
   const handleChangeTab = (filter: string) => () => {
@@ -88,19 +88,19 @@ function ProfilePage() {
         )}를(을) 삭제하시겠습니까?\n취소 후 복구를 할 수 없습니다.`,
       )
     ) {
-      if (currentTab === USER_PROFILE_TAB.REVIEWS) {
+      if (currentTab === TAB.USER_PROFILE.REVIEWS) {
         deleteReviewMutation.mutate(index as number, {
           onSuccess: deleteSuccessOption,
           onError: ({ message }) => alert(message),
         });
       }
-      if (currentTab === USER_PROFILE_TAB.REVIEW_FORMS) {
+      if (currentTab === TAB.USER_PROFILE.REVIEW_FORMS) {
         deleteReviewFormMutation.mutate(index as string, {
           onSuccess: deleteSuccessOption,
           onError: ({ message }) => alert(message),
         });
       }
-      if (currentTab === USER_PROFILE_TAB.TEMPLATES) {
+      if (currentTab === TAB.USER_PROFILE.TEMPLATES) {
         deleteTemplateMutation.mutate(index as number, {
           onSuccess: deleteSuccessOption,
           onError: ({ message }) => alert(message),

--- a/frontend/src/service/user/pages/ProfilePage/useProfilePageQueries.ts
+++ b/frontend/src/service/user/pages/ProfilePage/useProfilePageQueries.ts
@@ -1,4 +1,4 @@
-import { USER_PROFILE_TAB } from 'constant';
+import { TAB } from 'constant';
 import { Tabs } from 'types';
 
 import { useDeleteReviewAnswer, useDeleteReviewForm } from 'service/@shared/hooks/queries/review';
@@ -14,9 +14,9 @@ function useProfilePageQueries(currentTab: Tabs, socialIdPrams: string, pageNumb
   const socialId = Number(socialIdPrams);
 
   const useGetQueries = {
-    [USER_PROFILE_TAB.REVIEWS]: useGetUserReviewAnswer,
-    [USER_PROFILE_TAB.REVIEW_FORMS]: useGetUserReviewForms,
-    [USER_PROFILE_TAB.TEMPLATES]: useGetUserTemplates,
+    [TAB.USER_PROFILE.REVIEWS]: useGetUserReviewAnswer,
+    [TAB.USER_PROFILE.REVIEW_FORMS]: useGetUserReviewForms,
+    [TAB.USER_PROFILE.TEMPLATES]: useGetUserTemplates,
   };
 
   const deleteReviewMutation = useDeleteReviewAnswer();

--- a/frontend/src/service/user/pages/ProfilePage/useProfilePageQueries.ts
+++ b/frontend/src/service/user/pages/ProfilePage/useProfilePageQueries.ts
@@ -1,4 +1,4 @@
-import { TAB } from 'constant';
+import { FILTER } from 'constant';
 import { Tabs } from 'types';
 
 import { useDeleteReviewAnswer, useDeleteReviewForm } from 'service/@shared/hooks/queries/review';
@@ -14,9 +14,9 @@ function useProfilePageQueries(currentTab: Tabs, socialIdPrams: string, pageNumb
   const socialId = Number(socialIdPrams);
 
   const useGetQueries = {
-    [TAB.USER_PROFILE.REVIEWS]: useGetUserReviewAnswer,
-    [TAB.USER_PROFILE.REVIEW_FORMS]: useGetUserReviewForms,
-    [TAB.USER_PROFILE.TEMPLATES]: useGetUserTemplates,
+    [FILTER.USER_PROFILE_TAB.REVIEWS]: useGetUserReviewAnswer,
+    [FILTER.USER_PROFILE_TAB.REVIEW_FORMS]: useGetUserReviewForms,
+    [FILTER.USER_PROFILE_TAB.TEMPLATES]: useGetUserTemplates,
   };
 
   const deleteReviewMutation = useDeleteReviewAnswer();

--- a/frontend/src/service/user/pages/ProfilePage/view/Controller/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/view/Controller/index.tsx
@@ -4,7 +4,7 @@ import { faPenToSquare, faUser } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { GITHUB_PROFILE_URL, TAB } from 'constant';
+import { GITHUB_PROFILE_URL, FILTER } from 'constant';
 import { Tabs } from 'types';
 
 import { Text, Button } from 'common/components';
@@ -22,7 +22,7 @@ const Container = ({ children }: ContainerProps) => {
 const Profile = ({ profileUrl }: Record<string, string>) => {
   return (
     <div className={styles.profileImage} style={{ backgroundImage: `url(${profileUrl})` }}>
-      <div className={styles.activeIcon}>🦖</div>
+      <div className={styles.activeIcon}>🐤</div>
     </div>
   );
 };
@@ -90,25 +90,25 @@ const TabNavigator = ({ currentTab, onTabClick }: TabNavigatorProps) => {
 
       <li
         className={cn(styles.item, {
-          [styles.focus]: currentTab === TAB.USER_PROFILE.REVIEWS,
+          [styles.focus]: currentTab === FILTER.USER_PROFILE_TAB.REVIEWS,
         })}
-        onClick={onTabClick(TAB.USER_PROFILE.REVIEWS)}
+        onClick={onTabClick(FILTER.USER_PROFILE_TAB.REVIEWS)}
       >
         작성한 회고글
       </li>
       <li
         className={cn(styles.item, {
-          [styles.focus]: currentTab === TAB.USER_PROFILE.REVIEW_FORMS,
+          [styles.focus]: currentTab === FILTER.USER_PROFILE_TAB.REVIEW_FORMS,
         })}
-        onClick={onTabClick(TAB.USER_PROFILE.REVIEW_FORMS)}
+        onClick={onTabClick(FILTER.USER_PROFILE_TAB.REVIEW_FORMS)}
       >
         생성한 질문지
       </li>
       <li
         className={cn(styles.item, {
-          [styles.focus]: currentTab === TAB.USER_PROFILE.TEMPLATES,
+          [styles.focus]: currentTab === FILTER.USER_PROFILE_TAB.TEMPLATES,
         })}
-        onClick={onTabClick(TAB.USER_PROFILE.TEMPLATES)}
+        onClick={onTabClick(FILTER.USER_PROFILE_TAB.TEMPLATES)}
       >
         생성한 템플릿
       </li>

--- a/frontend/src/service/user/pages/ProfilePage/view/Controller/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/view/Controller/index.tsx
@@ -4,7 +4,7 @@ import { faPenToSquare, faUser } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { GITHUB_PROFILE_URL, USER_PROFILE_TAB } from 'constant';
+import { GITHUB_PROFILE_URL, TAB } from 'constant';
 import { Tabs } from 'types';
 
 import { Text, Button } from 'common/components';
@@ -90,25 +90,25 @@ const TabNavigator = ({ currentTab, onTabClick }: TabNavigatorProps) => {
 
       <li
         className={cn(styles.item, {
-          [styles.focus]: currentTab === USER_PROFILE_TAB.REVIEWS,
+          [styles.focus]: currentTab === TAB.USER_PROFILE.REVIEWS,
         })}
-        onClick={onTabClick(USER_PROFILE_TAB.REVIEWS)}
+        onClick={onTabClick(TAB.USER_PROFILE.REVIEWS)}
       >
         작성한 회고글
       </li>
       <li
         className={cn(styles.item, {
-          [styles.focus]: currentTab === USER_PROFILE_TAB.REVIEW_FORMS,
+          [styles.focus]: currentTab === TAB.USER_PROFILE.REVIEW_FORMS,
         })}
-        onClick={onTabClick(USER_PROFILE_TAB.REVIEW_FORMS)}
+        onClick={onTabClick(TAB.USER_PROFILE.REVIEW_FORMS)}
       >
         생성한 질문지
       </li>
       <li
         className={cn(styles.item, {
-          [styles.focus]: currentTab === USER_PROFILE_TAB.TEMPLATES,
+          [styles.focus]: currentTab === TAB.USER_PROFILE.TEMPLATES,
         })}
-        onClick={onTabClick(USER_PROFILE_TAB.TEMPLATES)}
+        onClick={onTabClick(TAB.USER_PROFILE.TEMPLATES)}
       >
         생성한 템플릿
       </li>

--- a/frontend/src/service/user/pages/ProfilePage/view/Controller/styles.module.scss
+++ b/frontend/src/service/user/pages/ProfilePage/view/Controller/styles.module.scss
@@ -18,6 +18,7 @@
     background-color: $GLOBAL_COLOR_WHITE_900;
 
     .active-icon {
+      font-size: 1.6rem;
       position: absolute;
       display: flex;
       justify-content: center;

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,9 +1,14 @@
-import { ErrorResponse } from 'types';
-
 import { UseMutationOptions } from '@tanstack/react-query';
+
+import { ErrorResponse } from 'types';
 
 export type UseCustomMutationOptions<TData = unknown> = UseMutationOptions<
   TData,
   ErrorResponse,
   unknown
 >;
+
+export interface InfiniteItem<TData> {
+  data: TData;
+  currentPage: number;
+}

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -49,6 +49,7 @@ export interface ReviewPublicAnswer extends ReviewFormAnswer {
 export type ReviewFormAnswerList = ReviewFormAnswer[];
 
 export interface ReviewPublicAnswerList {
+  isLastPage: boolean;
   numberOfReviews: number;
   reviews: ReviewPublicAnswer[];
 }
@@ -116,6 +117,7 @@ export type GetReviewFormAnswerResponse = {
 };
 
 export interface GetReviewPublicAnswerResponse {
+  isLastPage: boolean;
   numberOfReviews: number;
   reviews: Array<{
     id: number;

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -27,6 +27,7 @@ export interface ReviewForm {
   title: string;
   questions: Question[];
   info: UserContentRequireField;
+  participants?: UserProfile[];
 }
 
 export interface ReviewAnswer {
@@ -46,7 +47,10 @@ export interface ReviewPublicAnswer extends ReviewFormAnswer {
   likes: number;
 }
 
-export type ReviewFormAnswerList = ReviewFormAnswer[];
+export type ReviewFormAnswerList = {
+  isLastPage: boolean;
+  reviews: ReviewFormAnswer[];
+};
 
 export interface ReviewPublicAnswerList {
   isLastPage: boolean;
@@ -86,6 +90,7 @@ export interface GetReviewFormResponse extends ReviewFormResponse {
   updatedAt: number;
   creator: UserProfile;
   isCreator: boolean;
+  participants: UserProfile[];
 }
 
 export interface GetReviewAnswerResponse {
@@ -102,6 +107,7 @@ export interface GetReviewAnswerResponse {
 
 export type GetReviewFormAnswerResponse = {
   numberOfReviews: number;
+  isLastPage: boolean;
   reviews: Array<{
     id: number;
     reviewTitle: string;
@@ -189,3 +195,5 @@ export type DeleteReviewFormResponse = null;
 export type DeleteReviewAnswerResponse = null;
 
 export type TimelineFilterType = 'trend' | 'latest';
+
+export type DisplayModeType = 'list' | 'sheet';

--- a/frontend/src/types/review.ts
+++ b/frontend/src/types/review.ts
@@ -187,3 +187,5 @@ export type UpdateReviewAnswerResponse = null;
 export type DeleteReviewFormResponse = null;
 
 export type DeleteReviewAnswerResponse = null;
+
+export type TimelineFilterType = 'trend' | 'latest';


### PR DESCRIPTION
### useIntersectionObserver 훅 구현
범용적으로 사용할 수 있도록 커스텀훅으로 구현했습니다. 사용 방법은 코드레벨에서 코멘트 하겠습니다.

### 오버뷰페이지 무한스크롤 구현
https://user-images.githubusercontent.com/51396282/191670945-3164f4a6-dedf-40a5-a21a-582e04b0fbff.mov

### 페이지네이션
백엔드 페이지네이션 전반적인 API 수정에 따른 프론트엔드 적용

### 데모데이
- 데모데이를 위해 구독 관련 UI 제거했습니다.
- 공룡에서 오리로 프로필페이지 아이콘 변경했습니다.
- 검색 기능 pending 페이지로 라우팅 처리했습니다.

> 코드레벨에서 추가적인 설명 코멘트로 달겠습니다 :)