### PR TITLE
batch 조회 적용 및 정렬 기준 수정

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/member/repository/MemberRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/member/repository/MemberRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import com.reviewduck.member.domain.Member;
+import com.reviewduck.review.domain.ReviewForm;
 
 public interface MemberRepository extends Repository<Member, Long> {
 
@@ -16,6 +17,6 @@ public interface MemberRepository extends Repository<Member, Long> {
 
     Optional<Member> findBySocialId(String socialId);
 
-    @Query("select m from Member m where m.id in (select distinct r.member.id from Review r where r.reviewForm in (select rf from ReviewForm rf where rf.code = :code))")
-    List<Member> findAllParticipantsByReviewFormCode(String code);
+    @Query("select m from Member m where m.id in (select distinct r.member.id from Review r where r.reviewForm = :form)")
+    List<Member> findAllParticipantsByReviewFormCode(ReviewForm form);
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/member/repository/MemberRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/member/repository/MemberRepository.java
@@ -1,7 +1,9 @@
 package com.reviewduck.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import com.reviewduck.member.domain.Member;
@@ -13,4 +15,7 @@ public interface MemberRepository extends Repository<Member, Long> {
     Optional<Member> findById(Long id);
 
     Optional<Member> findBySocialId(String socialId);
+
+    @Query("select m from Member m where m.id in (select distinct r.member.id from Review r where r.reviewForm in (select rf from ReviewForm rf where rf.code = :code))")
+    List<Member> findAllParticipantsByReviewFormCode(String code);
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewController.java
@@ -71,7 +71,7 @@ public class ReviewController {
     public TimelineReviewsResponse findAllPublic(@AuthenticationPrincipal Member member,
         @RequestParam(required = false, defaultValue = DEFAULT_PAGE) int page,
         @RequestParam(required = false, defaultValue = DEFAULT_SIZE) int size,
-        @RequestParam(required = false) String sort) {
+        @RequestParam(required = false, defaultValue = "latest") String sort) {
 
         info("/api/reviews/public?page=" + page + "&size=" + size + "&sort=" + sort, "GET", "");
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
@@ -104,7 +104,7 @@ public class ReviewFormController {
         @PathVariable String reviewFormCode,
         @RequestParam(required = false, defaultValue = DEFAULT_PAGE) int page,
         @RequestParam(required = false, defaultValue = DEFAULT_SIZE) int size,
-        @RequestParam String displayType) {
+        @RequestParam(required = false, defaultValue = "list") String displayType) {
 
         info("/api/review-forms/" + reviewFormCode + "/reviews?displayType=" + displayType, "GET", "");
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
@@ -77,7 +77,7 @@ public class ReviewFormController {
         info("/api/review-forms/" + reviewFormCode, "GET", "");
 
         ReviewForm reviewForm = reviewFormService.findByCode(reviewFormCode);
-        List<Member> participants = reviewService.findAllParticipantsByCode(reviewFormCode);
+        List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewFormCode);
 
         return ReviewFormResponse.of(reviewForm, member, participants);
     }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
@@ -77,7 +77,7 @@ public class ReviewFormController {
         info("/api/review-forms/" + reviewFormCode, "GET", "");
 
         ReviewForm reviewForm = reviewFormService.findByCode(reviewFormCode);
-        List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewFormCode);
+        List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewForm);
 
         return ReviewFormResponse.of(reviewForm, member, participants);
     }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
@@ -17,6 +17,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 
+import org.hibernate.annotations.BatchSize;
+
 import com.reviewduck.common.domain.BaseDate;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.exception.ReviewException;

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewsOfReviewFormResponse.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/response/ReviewsOfReviewFormResponse.java
@@ -31,5 +31,4 @@ public class ReviewsOfReviewFormResponse {
     public boolean getIsLastPage() {
         return isLastPage;
     }
-
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
@@ -3,8 +3,6 @@ package com.reviewduck.review.repository;
 import java.util.List;
 import java.util.Optional;
 
-import org.hibernate.annotations.BatchSize;
-import org.hibernate.annotations.JoinColumnOrFormula;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
@@ -22,9 +20,6 @@ public interface ReviewRepository extends Repository<Review, Long> {
     Optional<Review> findById(long reviewId);
 
     Page<Review> findByReviewForm(ReviewForm reviewForm, Pageable pageable);
-
-    @Query("select r from Review r join fetch r.member where r.reviewForm.code = :reviewFormCode")
-    List<Review> findAllByReviewFormCode(String reviewFormCode);
 
     Page<Review> findByIsPrivateFalse(Pageable pageable);
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
@@ -21,7 +21,6 @@ public interface ReviewRepository extends Repository<Review, Long> {
 
     Optional<Review> findById(long reviewId);
 
-    @BatchSize(size = 20)
     Page<Review> findByReviewForm(ReviewForm reviewForm, Pageable pageable);
 
     @Query("select r from Review r join fetch r.member where r.reviewForm.code = :reviewFormCode")

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
@@ -3,6 +3,8 @@ package com.reviewduck.review.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.JoinColumnOrFormula;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
@@ -19,6 +21,7 @@ public interface ReviewRepository extends Repository<Review, Long> {
 
     Optional<Review> findById(long reviewId);
 
+    @BatchSize(size = 20)
     Page<Review> findByReviewForm(ReviewForm reviewForm, Pageable pageable);
 
     @Query("select r from Review r join fetch r.member where r.reviewForm.code = :reviewFormCode")

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
@@ -1,6 +1,7 @@
 package com.reviewduck.review.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
@@ -12,12 +13,15 @@ import org.springframework.transaction.annotation.Transactional;
 import com.reviewduck.auth.exception.AuthorizationException;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
+import com.reviewduck.member.repository.MemberRepository;
 import com.reviewduck.member.service.MemberService;
+import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.domain.ReviewForm;
 import com.reviewduck.review.domain.ReviewFormQuestion;
 import com.reviewduck.review.dto.request.ReviewFormCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormUpdateRequest;
 import com.reviewduck.review.repository.ReviewFormRepository;
+import com.reviewduck.review.repository.ReviewRepository;
 import com.reviewduck.review.vo.ReviewFormSortType;
 import com.reviewduck.template.domain.Template;
 import com.reviewduck.template.service.TemplateService;
@@ -30,6 +34,7 @@ import lombok.AllArgsConstructor;
 public class ReviewFormService {
 
     private final ReviewFormRepository reviewFormRepository;
+    private final MemberRepository memberRepository;
 
     private final ReviewFormQuestionService reviewFormQuestionService;
     private final TemplateService templateService;
@@ -105,5 +110,9 @@ public class ReviewFormService {
         if (!reviewForm.isMine(member)) {
             throw new AuthorizationException(message);
         }
+    }
+
+    public List<Member> findAllParticipantsByCode(String code) {
+        return memberRepository.findAllParticipantsByReviewFormCode(code);
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
@@ -112,7 +112,7 @@ public class ReviewFormService {
         }
     }
 
-    public List<Member> findAllParticipantsByCode(String code) {
-        return memberRepository.findAllParticipantsByReviewFormCode(code);
+    public List<Member> findAllParticipantsByCode(ReviewForm reviewForm) {
+        return memberRepository.findAllParticipantsByReviewFormCode(reviewForm);
     }
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewService.java
@@ -2,7 +2,6 @@ package com.reviewduck.review.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -77,15 +76,6 @@ public class ReviewService {
         PageRequest pageRequest = PageRequest.of(page, size, sort);
 
         return reviewRepository.findByReviewForm(reviewForm, pageRequest);
-    }
-
-    public List<Member> findAllParticipantsByCode(String code) {
-        List<Review> reviews = reviewRepository.findAllByReviewFormCode(code);
-
-        return reviews.stream()
-            .map(Review::getMember)
-            .distinct()
-            .collect(Collectors.toUnmodifiableList());
     }
 
     public Page<Review> findAllPublic(int page, int size, String sort) {

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/vo/ReviewSortType.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/vo/ReviewSortType.java
@@ -9,7 +9,8 @@ import java.util.Arrays;
  */
 public enum ReviewSortType {
 
-    LATEST("latest", "updatedAt"),
+    LATEST("latest", "createdAt"),
+    UPDATE("update", "updatedAt"),
     TREND("trend", "likes");
 
     private final String param;

--- a/backend/reviewduck/src/main/java/com/reviewduck/template/controller/TemplateController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/controller/TemplateController.java
@@ -87,7 +87,7 @@ public class TemplateController {
     public TemplatesResponse findAll(@AuthenticationPrincipal Member member,
         @RequestParam(required = false, defaultValue = DEFAULT_PAGE) int page,
         @RequestParam(required = false, defaultValue = DEFAULT_SIZE) int size,
-        @RequestParam(required = false) String sort) {
+        @RequestParam(required = false, defaultValue = "trend") String sort) {
 
         info("/api/templates?page=" + page + " size=" + size, "GET", "");
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/template/vo/TemplateSortType.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/vo/TemplateSortType.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
  */
 public enum TemplateSortType {
 
-    LATEST("latest", "updatedAt"),
+    LATEST("latest", "createdAt"),
     TREND("trend", "usedCount");
 
     private final String param;

--- a/backend/reviewduck/src/main/resources/application.properties
+++ b/backend/reviewduck/src/main/resources/application.properties
@@ -15,6 +15,7 @@ spring.datasource.password=${databasePassword}
 spring.datasource.hikari.maximum-pool-size=${connectionPoolSize}
 # jpa
 spring.jpa.hibernate.ddl-auto=none
+spring.jpa.properties.hibernate.default_batch_fetch_size = 20
 # security
 security.oauth2.client-id=${clientId}
 security.oauth2.client-secret=${clientSecret}

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
@@ -362,7 +362,7 @@ public class ReviewFormServiceTest {
             reviewService.save(member1, reviewForm.getCode(), reviewCreateRequest);
 
             // when
-            List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewForm.getCode());
+            List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewForm);
 
             // then
             assertAll(

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
@@ -21,8 +21,12 @@ import com.reviewduck.auth.exception.AuthorizationException;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.service.MemberService;
+import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.domain.ReviewForm;
 import com.reviewduck.review.domain.ReviewFormQuestion;
+import com.reviewduck.review.dto.request.AnswerCreateRequest;
+import com.reviewduck.review.dto.request.ReviewContentCreateRequest;
+import com.reviewduck.review.dto.request.ReviewCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormQuestionCreateRequest;
 import com.reviewduck.review.dto.request.ReviewFormQuestionUpdateRequest;
@@ -43,6 +47,9 @@ public class ReviewFormServiceTest {
     private ReviewFormService reviewFormService;
 
     @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
     private TemplateService templateService;
 
     @Autowired
@@ -58,6 +65,18 @@ public class ReviewFormServiceTest {
 
         Member tempMember2 = new Member("2", "woni", "워니", "testUrl2");
         member2 = memberService.save(tempMember2);
+    }
+
+    private ReviewForm saveReviewForm(Member member) throws InterruptedException {
+        Thread.sleep(1);
+
+        List<ReviewFormQuestionCreateRequest> createRequests = List.of(
+            new ReviewFormQuestionCreateRequest("question1", "description1"),
+            new ReviewFormQuestionCreateRequest("question2", "description2"));
+
+        ReviewFormCreateRequest createRequest = new ReviewFormCreateRequest("title", createRequests);
+
+        return reviewFormService.save(member, createRequest);
     }
 
     @Nested
@@ -320,6 +339,37 @@ public class ReviewFormServiceTest {
                 .hasMessageContaining("존재하지 않는 회고 폼입니다.");
         }
 
+        @Test
+        @DisplayName("회고 폼 참여자 정보를 조회한다.")
+        void findAllParticipants() {
+            // given
+            String reviewFormTitle = "title";
+            List<ReviewFormQuestionCreateRequest> questions = List.of(
+                new ReviewFormQuestionCreateRequest("question1", "description1"),
+                new ReviewFormQuestionCreateRequest("question2", "description2"));
+
+            ReviewFormCreateRequest createRequest = new ReviewFormCreateRequest(reviewFormTitle, questions);
+            ReviewForm reviewForm = reviewFormService.save(member1, createRequest);
+
+            long questionId1 = reviewForm.getReviewFormQuestions().get(0).getId();
+            long questionId2 = reviewForm.getReviewFormQuestions().get(1).getId();
+
+            ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(false, List.of(
+                new ReviewContentCreateRequest(questionId1, new AnswerCreateRequest("answer1")),
+                new ReviewContentCreateRequest(questionId2, new AnswerCreateRequest("answer2"))
+            ));
+
+            reviewService.save(member1, reviewForm.getCode(), reviewCreateRequest);
+
+            // when
+            List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewForm.getCode());
+
+            // then
+            assertAll(
+                () -> assertThat(participants).hasSize(1),
+                () -> assertThat(participants).contains(member1)
+            );
+        }
     }
 
     @Nested
@@ -336,7 +386,7 @@ public class ReviewFormServiceTest {
             // when
             int page = 0;
             int size = 3;
-            List<ReviewForm> myReviewForms = reviewFormService.findBySocialId(member1.getSocialId(), page ,size)
+            List<ReviewForm> myReviewForms = reviewFormService.findBySocialId(member1.getSocialId(), page, size)
                 .getContent();
 
             // then
@@ -366,7 +416,7 @@ public class ReviewFormServiceTest {
             // when
             int page = 0;
             int size = 3;
-            List<ReviewForm> myReviewForms = reviewFormService.findBySocialId(member1.getSocialId(), page ,size)
+            List<ReviewForm> myReviewForms = reviewFormService.findBySocialId(member1.getSocialId(), page, size)
                 .getContent();
 
             // then
@@ -537,17 +587,5 @@ public class ReviewFormServiceTest {
                 .hasMessageContaining("존재하지 않는 회고 폼입니다.");
         }
 
-    }
-
-    private ReviewForm saveReviewForm(Member member) throws InterruptedException {
-        Thread.sleep(1);
-
-        List<ReviewFormQuestionCreateRequest> createRequests = List.of(
-            new ReviewFormQuestionCreateRequest("question1", "description1"),
-            new ReviewFormQuestionCreateRequest("question2", "description2"));
-
-        ReviewFormCreateRequest createRequest = new ReviewFormCreateRequest("title", createRequests);
-
-        return reviewFormService.save(member, createRequest);
     }
 }

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewServiceTest.java
@@ -264,27 +264,6 @@ public class ReviewServiceTest {
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("존재하지 않는 회고 폼입니다.");
         }
-
-        @Test
-        @DisplayName("회고 폼 참여자 정보를 조회한다.")
-        void findAllParticipants() throws InterruptedException {
-            // given
-            saveReview(reviewForm1, member1, false);
-            saveReview(reviewForm1, member1, true);
-            saveReview(reviewForm1, member1, true);
-
-            saveReview(reviewForm2, member1, false);
-            saveReview(reviewForm2, member2, true);
-
-            // when
-            List<Member> participants = reviewService.findAllParticipantsByCode(reviewForm1.getCode());
-
-            // then
-            assertAll(
-                () -> assertThat(participants).hasSize(1),
-                () -> assertTrue(participants.contains(member1))
-            );
-        }
     }
 
     @Nested

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/vo/ReviewSortTypeTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/vo/ReviewSortTypeTest.java
@@ -13,7 +13,7 @@ class ReviewSortTypeTest {
     @DisplayName("파라미터에 맞는 정렬 기준을 반환한다.")
     void getSortBy() {
         assertThat(ReviewSortType.getSortBy("latest"))
-            .isEqualTo("updatedAt");
+            .isEqualTo("createdAt");
     }
 
     @ParameterizedTest

--- a/backend/reviewduck/src/test/java/com/reviewduck/template/vo/TemplateSortTypeTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/template/vo/TemplateSortTypeTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 class TemplateSortTypeTest {
 
     @ParameterizedTest
-    @CsvSource(value = {"latest:updatedAt", "trend:usedCount"}, delimiter = ':')
+    @CsvSource(value = {"latest:createdAt", "trend:usedCount"}, delimiter = ':')
     @DisplayName("파라미터에 맞는 정렬 기준을 반환한다.")
     void getSortBy(String param, String sortBy) {
         assertThat(TemplateSortType.getSortBy(param))


### PR DESCRIPTION
회고폼에 대한 회고 답변들을 조회하는 경우, batch 조회를 하도록 `ReviewRepository`를 수정하였습니다. 
 
`TemplateSortType`과 `ReviewSortType`의 `LATEST`를 `updatedAt` -> `createdAt` 기준으로 변경하고,
`ReviewSortType`에 `updatedAt `기준 정렬을 의미하는 `UPDATE`를 추가하였습니다.