### PR TITLE
회고를 생성하지 않은 질문지를 삭제하면 Hard Delete 하도록 변경

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/member/service/MemberService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.reviewduck.member.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
@@ -9,6 +10,7 @@ import com.reviewduck.auth.exception.AuthorizationException;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.repository.MemberRepository;
+import com.reviewduck.review.domain.ReviewForm;
 
 import lombok.AllArgsConstructor;
 
@@ -36,6 +38,10 @@ public class MemberService {
 
     public Optional<Member> findBySocialId(String socialId) {
         return memberRepository.findBySocialId(socialId);
+    }
+
+    public List<Member> findAllParticipantsByCode(ReviewForm reviewForm) {
+        return memberRepository.findAllParticipantsByReviewFormCode(reviewForm);
     }
 
     @Transactional

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/controller/ReviewFormController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.reviewduck.auth.support.AuthenticationPrincipal;
 import com.reviewduck.member.domain.Member;
+import com.reviewduck.member.service.MemberService;
 import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.domain.ReviewForm;
 import com.reviewduck.review.dto.controller.request.ReviewCreateRequest;
@@ -44,6 +45,7 @@ public class ReviewFormController {
 
     private final ReviewFormService reviewFormService;
     private final ReviewService reviewService;
+    private final MemberService memberService;
 
     @Operation(summary = "회고 폼을 생성한다.")
     @PostMapping
@@ -77,7 +79,7 @@ public class ReviewFormController {
         info("/api/review-forms/" + reviewFormCode, "GET", "");
 
         ReviewForm reviewForm = reviewFormService.findByCode(reviewFormCode);
-        List<Member> participants = reviewFormService.findAllParticipantsByCode(reviewForm);
+        List<Member> participants = memberService.findAllParticipantsByCode(reviewForm);
 
         return ReviewFormResponse.of(reviewForm, member, participants);
     }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/domain/ReviewForm.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/domain/ReviewForm.java
@@ -24,8 +24,8 @@ import com.reviewduck.common.domain.BaseDate;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.exception.ReviewFormException;
-import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
-import com.reviewduck.review.service.ReviewFormQuestionUpdateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionUpdateDto;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/service/ReviewFormQuestionCreateDto.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/service/ReviewFormQuestionCreateDto.java
@@ -1,4 +1,4 @@
-package com.reviewduck.review.service;
+package com.reviewduck.review.dto.service;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/service/ReviewFormQuestionUpdateDto.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/service/ReviewFormQuestionUpdateDto.java
@@ -1,4 +1,4 @@
-package com.reviewduck.review.service;
+package com.reviewduck.review.dto.service;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/dto/service/ServiceDtoConverter.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/dto/service/ServiceDtoConverter.java
@@ -1,4 +1,4 @@
-package com.reviewduck.review.service;
+package com.reviewduck.review.dto.service;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewFormRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewFormRepository.java
@@ -21,7 +21,7 @@ public interface ReviewFormRepository extends Repository<ReviewForm, Long> {
 
     @Modifying
     @Query("update ReviewForm r set r.isActive = false where r.id = :#{#reviewForm.id}")
-    void deleteSoftly(ReviewForm reviewForm);
+    void inactivate(ReviewForm reviewForm);
 
     void delete(ReviewForm reviewForm);
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewFormRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewFormRepository.java
@@ -21,5 +21,7 @@ public interface ReviewFormRepository extends Repository<ReviewForm, Long> {
 
     @Modifying
     @Query("update ReviewForm r set r.isActive = false where r.id = :#{#reviewForm.id}")
+    void deleteSoftly(ReviewForm reviewForm);
+
     void delete(ReviewForm reviewForm);
 }

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/repository/ReviewRepository.java
@@ -1,6 +1,5 @@
 package com.reviewduck.review.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -26,6 +25,8 @@ public interface ReviewRepository extends Repository<Review, Long> {
     Page<Review> findByMember(Member member, Pageable pageable);
 
     Page<Review> findByMemberAndIsPrivateFalse(Member member, Pageable pageable);
+
+    boolean existsByReviewForm(ReviewForm reviewForm);
 
     @Modifying(clearAutomatically = true)
     @Query("update Review r set r.likes = r.likes + :likeCount where r.id = :#{#review.id}")

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
@@ -95,7 +95,7 @@ public class ReviewFormService {
         ReviewForm reviewForm = findByCode(reviewFormCode);
         validateReviewFormIsMine(member, reviewForm, "본인이 생성한 회고 폼이 아니면 삭제할 수 없습니다.");
         if (reviewRepository.existsByReviewForm(reviewForm)) {
-            reviewFormRepository.deleteSoftly(reviewForm);
+            reviewFormRepository.inactivate(reviewForm);
             return;
         }
         reviewFormRepository.delete(reviewForm);

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
@@ -32,8 +32,8 @@ import lombok.AllArgsConstructor;
 public class ReviewFormService {
 
     private final ReviewFormRepository reviewFormRepository;
-
     private final ReviewRepository reviewRepository;
+
     private final TemplateService templateService;
     private final MemberService memberService;
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/service/ReviewFormService.java
@@ -3,7 +3,6 @@ package com.reviewduck.review.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -13,11 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 import com.reviewduck.auth.exception.AuthorizationException;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
-import com.reviewduck.member.repository.MemberRepository;
 import com.reviewduck.member.service.MemberService;
 import com.reviewduck.review.domain.ReviewForm;
 import com.reviewduck.review.dto.controller.request.ReviewFormCreateRequest;
 import com.reviewduck.review.dto.controller.request.ReviewFormUpdateRequest;
+import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
+import com.reviewduck.review.dto.service.ServiceDtoConverter;
 import com.reviewduck.review.repository.ReviewFormRepository;
 import com.reviewduck.review.repository.ReviewRepository;
 import com.reviewduck.review.vo.ReviewFormSortType;
@@ -75,10 +75,6 @@ public class ReviewFormService {
         PageRequest pageRequest = PageRequest.of(page, size, sort);
 
         return reviewFormRepository.findByMemberAndIsActiveTrue(member, pageRequest);
-    }
-
-    public List<Member> findAllParticipantsByCode(ReviewForm reviewForm) {
-        return memberService.findAllParticipantsByCode(reviewForm);
     }
 
     @Transactional

--- a/backend/reviewduck/src/main/java/com/reviewduck/template/service/TemplateService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/service/TemplateService.java
@@ -15,7 +15,6 @@ import com.reviewduck.member.service.MemberService;
 import com.reviewduck.template.domain.Template;
 import com.reviewduck.template.dto.controller.request.TemplateCreateRequest;
 import com.reviewduck.template.dto.controller.request.TemplateUpdateRequest;
-import com.reviewduck.template.dto.service.ServiceDtoConverter;
 import com.reviewduck.template.repository.TemplateRepository;
 import com.reviewduck.template.vo.TemplateSortType;
 

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
@@ -81,7 +81,7 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
 
             post("/api/review-forms/" + code, createRequest, accessToken2);
 
-            // deleteSoftly question2 and add question4 of reviewForm
+            // delete question2 and add question4 of reviewForm
             List<ReviewFormQuestionUpdateRequest> updateQuestions = List.of(
                 new ReviewFormQuestionUpdateRequest(1L, "new question1", "new description1"),
                 new ReviewFormQuestionUpdateRequest(3L, "new question3", "new description3"),

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewAcceptanceTest.java
@@ -81,7 +81,7 @@ public class ReviewAcceptanceTest extends AcceptanceTest {
 
             post("/api/review-forms/" + code, createRequest, accessToken2);
 
-            // delete question2 and add question4 of reviewForm
+            // deleteSoftly question2 and add question4 of reviewForm
             List<ReviewFormQuestionUpdateRequest> updateQuestions = List.of(
                 new ReviewFormQuestionUpdateRequest(1L, "new question1", "new description1"),
                 new ReviewFormQuestionUpdateRequest(3L, "new question3", "new description3"),

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewFormAcceptanceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/acceptance/ReviewFormAcceptanceTest.java
@@ -58,11 +58,11 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("회고 폼 생성")
+    @DisplayName("회고 질문지 생성")
     class createReviewForm {
 
         @Test
-        @DisplayName("회고 폼을 생성한다.")
+        @DisplayName("회고 질문지를 생성한다.")
         void createReviewForm() {
             // given
             String reviewTitle = "title";
@@ -90,7 +90,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("템플릿을 기반으로 작성된 후 수정된 회고 폼을 생성")
+    @DisplayName("템플릿을 기반으로 작성된 후 수정된 회고 질문지를 생성")
     class createReviewFormByTemplate {
 
         @Test
@@ -199,11 +199,11 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("특정 회고 폼 조회")
+    @DisplayName("특정 회고 질문지 조회")
     class findReviewForm {
 
         @Test
-        @DisplayName("특정 회고 폼을 조회한다.")
+        @DisplayName("특정 회고 질문지를 조회한다.")
         void findReviewForm() {
             // given
             String reviewTitle = "title";
@@ -232,7 +232,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("회고 폼이 존재하지 않는 경우 조회할 수 없다.")
+        @DisplayName("회고 질문지가 존재하지 않는 경우 조회할 수 없다.")
         void invalidReviewForm() {
             // when, then
             get("/api/review-forms/" + "AAAAAAAA", accessToken1).statusCode(HttpStatus.NOT_FOUND.value());
@@ -241,7 +241,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("사용자가 생성한 회고 폼 조회")
+    @DisplayName("사용자가 생성한 회고 질문지 조회")
     class findReviewFormsByMember {
 
         @Test
@@ -316,7 +316,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("특정 회고 폼을 기반으로 작성된 회고 조회")
+    @DisplayName("특정 회고 질문지를 기반으로 작성된 회고 조회")
     class findReviewsByCodeWithDisplayType {
 
         @Test
@@ -375,7 +375,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("특정 회고 폼을 기반으로 작성된 목록형 회고 조회")
+    @DisplayName("특정 회고 질문지를 기반으로 작성된 목록형 회고 조회")
     class findReviewsByCodeWithListDisplay {
 
         @Test
@@ -397,7 +397,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("특정 회고 폼을 기반으로 작성된 회고 답변 전체 중 특정 페이지를 조회한다.")
+        @DisplayName("특정 회고 질문지를 기반으로 작성된 회고 답변 전체 중 특정 페이지를 조회한다.")
         void findReviewsPageByCode() {
             // given
             String code = createReviewFormAndGetCode(accessToken1);
@@ -441,7 +441,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 회고 폼 코드에 대해 조회할 수 없다.")
+        @DisplayName("존재하지 않는 회고 질문지 코드에 대해 조회할 수 없다.")
         void invalidCode() {
             // when, then
             get("/api/review-forms/" + invalidCode + "/reviews?displayType=list", accessToken1)
@@ -451,7 +451,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("특정 회고 폼을 기반으로 작성된 시트형 회고 조회 (동기화)")
+    @DisplayName("특정 회고 질문지를 기반으로 작성된 시트형 회고 조회 (동기화)")
     class findReviewsByCodeWithSheetDisplay {
 
         @Test
@@ -473,7 +473,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("특정 회고 폼을 기반으로 작성되고 동기화된 회고 답변중 특정 페이지를 조회한다.")
+        @DisplayName("특정 회고 질문지를 기반으로 작성되고 동기화된 회고 답변중 특정 페이지를 조회한다.")
         void findReviewsByCode() {
             // given
             String code = createReviewFormAndGetCode(accessToken1);
@@ -523,7 +523,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 회고 폼 코드에 대해 조회할 수 없다.")
+        @DisplayName("존재하지 않는 회고 질문지 코드에 대해 조회할 수 없다.")
         void invalidCode() {
             // when, then
             get("/api/review-forms/" + invalidCode + "/reviews?displayType=sheet", accessToken1)
@@ -532,11 +532,11 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     }
 
     @Nested
-    @DisplayName("회고 폼 수정")
+    @DisplayName("회고 질문지 수정")
     class updateReviewForm {
 
         @Test
-        @DisplayName("회고 폼을 수정한다.")
+        @DisplayName("회고 질문지를 수정한다.")
         void updateReviewForm() {
             // given
             String reviewFormCode = createReviewFormAndGetCode(accessToken1);
@@ -565,7 +565,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("로그인하지 않은 상태로 회고 폼을 수정할 수 없다.")
+        @DisplayName("로그인하지 않은 상태로 회고 질문지를 수정할 수 없다.")
         void withoutLogin() {
             // given
             String createReviewFormCode = createReviewFormAndGetCode(accessToken1);
@@ -581,7 +581,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 회고 폼을 수정할 수 없다.")
+        @DisplayName("존재하지 않는 회고 질문지를 수정할 수 없다.")
         void invalidReviewForm() {
             // when, then
             String newReviewTitle = "new title";
@@ -594,7 +594,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("본인이 생성한 회고 폼이 아니면 수정할 수 없다.")
+        @DisplayName("본인이 생성한 회고 질문지가 아니면 수정할 수 없다.")
         void notMine() {
             // given
             String createReviewFormCode = createReviewFormAndGetCode(accessToken1);
@@ -617,8 +617,23 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
     class deleteReviewForm {
 
         @Test
-        @DisplayName("회고 폼을 삭제한다.")
-        void deleteReviewForm() {
+        @DisplayName("회고 질문지를 삭제한다(생성한 회고 있는 상태).")
+        void deleteReviewForm_reviewNotExists() {
+            // given
+            String createReviewFormCode = createReviewFormAndGetCode(accessToken1);
+            createReview(createReviewFormCode);
+
+            // when, then
+            delete("/api/review-forms/" + createReviewFormCode, accessToken1)
+                .statusCode(HttpStatus.NO_CONTENT.value());
+
+            get("/api/review-forms/" + createReviewFormCode, accessToken1)
+                .statusCode(HttpStatus.NOT_FOUND.value());
+        }
+
+        @Test
+        @DisplayName("회고 질문지를 삭제한다(생성한 회고 없는 상태).")
+        void deleteReviewForm_reviewExists() {
             // given
             String createReviewFormCode = createReviewFormAndGetCode(accessToken1);
 
@@ -631,7 +646,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("로그인하지 않은 상태로 회고 폼을 삭제할 수 없다.")
+        @DisplayName("로그인하지 않은 상태로 회고 질문지를 삭제할 수 없다.")
         void withoutLogin() {
             // given
             String createReviewFormCode = createReviewFormAndGetCode(accessToken1);
@@ -642,7 +657,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 회고 폼을 삭제할 수 없다.")
+        @DisplayName("존재하지 않는 회고 질문지를 삭제할 수 없다.")
         void invalidReviewForm() {
             // when, then
             delete("/api/review-forms/aaaaaaaa", accessToken1)
@@ -650,7 +665,7 @@ public class ReviewFormAcceptanceTest extends AcceptanceTest {
         }
 
         @Test
-        @DisplayName("본인이 생성한 회고 폼이 아니면 삭제할 수 없다.")
+        @DisplayName("본인이 생성한 회고 질문지가 아니면 삭제할 수 없다.")
         void noeMine() {
             // given
             String createReviewFormCode = createReviewFormAndGetCode(accessToken1);

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/domain/ReviewFormTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/domain/ReviewFormTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.params.provider.NullSource;
 import com.reviewduck.common.exception.NotFoundException;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.exception.ReviewFormException;
-import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
-import com.reviewduck.review.service.ReviewFormQuestionUpdateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionUpdateDto;
 
 class ReviewFormTest {
 

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/domain/ReviewTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/domain/ReviewTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.provider.NullSource;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.review.exception.ReviewException;
 import com.reviewduck.review.dto.service.QuestionAnswerCreateDto;
-import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
 
 public class ReviewTest {
 

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
@@ -95,7 +95,7 @@ public class ReviewFormRepositoryTest {
         ReviewForm expected = saveReviewForm(member1);
         ReviewForm reviewForm = saveReviewForm(member1);
 
-        reviewFormRepository.deleteSoftly(reviewForm);
+        reviewFormRepository.inactivate(reviewForm);
 
         // when
         int page = 0;
@@ -123,7 +123,7 @@ public class ReviewFormRepositoryTest {
         String reviewFormCode = reviewForm.getCode();
 
         // when
-        reviewFormRepository.deleteSoftly(reviewForm);
+        reviewFormRepository.inactivate(reviewForm);
 
         // then
         assertThat(reviewFormRepository.findByCodeAndIsActiveTrue(reviewFormCode).isEmpty()).isTrue();

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
@@ -18,7 +18,6 @@ import com.reviewduck.config.JpaAuditingConfig;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.repository.MemberRepository;
 import com.reviewduck.review.domain.ReviewForm;
-import com.reviewduck.review.domain.ReviewFormQuestion;
 import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
 
 @DataJpaTest
@@ -96,7 +95,7 @@ public class ReviewFormRepositoryTest {
         ReviewForm expected = saveReviewForm(member1);
         ReviewForm reviewForm = saveReviewForm(member1);
 
-        reviewFormRepository.delete(reviewForm);
+        reviewFormRepository.deleteSoftly(reviewForm);
 
         // when
         int page = 0;
@@ -124,7 +123,7 @@ public class ReviewFormRepositoryTest {
         String reviewFormCode = reviewForm.getCode();
 
         // when
-        reviewFormRepository.delete(reviewForm);
+        reviewFormRepository.deleteSoftly(reviewForm);
 
         // then
         assertThat(reviewFormRepository.findByCodeAndIsActiveTrue(reviewFormCode).isEmpty()).isTrue();

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
@@ -18,7 +18,7 @@ import com.reviewduck.config.JpaAuditingConfig;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.repository.MemberRepository;
 import com.reviewduck.review.domain.ReviewForm;
-import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
 
 @DataJpaTest
 @Import(JpaAuditingConfig.class)

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewFormRepositoryTest.java
@@ -28,6 +28,9 @@ public class ReviewFormRepositoryTest {
     private ReviewFormRepository reviewFormRepository;
 
     @Autowired
+    private TestReviewFormRepository testReviewFormRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     private Member member1;
@@ -116,8 +119,8 @@ public class ReviewFormRepositoryTest {
     }
 
     @Test
-    @DisplayName("삭제된 회고 폼을 코드로 조회할 수 없다.")
-    void NotFoundDeletedReviewFormByCode() throws InterruptedException {
+    @DisplayName("삭제된 회고 폼을 코드로 조회할 수 없다(inactive).")
+    void NotFoundInactivatedReviewFormByCode() throws InterruptedException {
         // given
         ReviewForm reviewForm = saveReviewForm(member1);
         String reviewFormCode = reviewForm.getCode();
@@ -126,7 +129,27 @@ public class ReviewFormRepositoryTest {
         reviewFormRepository.inactivate(reviewForm);
 
         // then
-        assertThat(reviewFormRepository.findByCodeAndIsActiveTrue(reviewFormCode).isEmpty()).isTrue();
+        assertAll(
+            () -> assertThat(reviewFormRepository.findByCodeAndIsActiveTrue(reviewFormCode).isEmpty()).isTrue(),
+            () -> assertThat(testReviewFormRepository.findByCode(reviewFormCode).isPresent()).isTrue()
+        );
+    }
+
+    @Test
+    @DisplayName("삭제된 회고 폼을 코드로 조회할 수 없다(delete).")
+    void NotFoundDeletedReviewFormByCode() throws InterruptedException {
+        // given
+        ReviewForm reviewForm = saveReviewForm(member1);
+        String reviewFormCode = reviewForm.getCode();
+
+        // when
+        reviewFormRepository.delete(reviewForm);
+
+        // then
+        assertAll(
+            () -> assertThat(reviewFormRepository.findByCodeAndIsActiveTrue(reviewFormCode).isEmpty()).isTrue(),
+            () -> assertThat(testReviewFormRepository.findByCode(reviewFormCode).isEmpty()).isTrue()
+        );
     }
 
     private ReviewForm saveReviewForm(Member member) throws InterruptedException {

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
@@ -26,7 +26,7 @@ import com.reviewduck.review.domain.Answer;
 import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.domain.ReviewForm;
 import com.reviewduck.review.dto.service.QuestionAnswerCreateDto;
-import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
+import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
 
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
@@ -246,7 +246,7 @@ public class ReviewRepositoryTest {
 
     @Test
     @DisplayName("특정 회고 질문지로 만든 회고가 존재하지 않는다.")
-    void existsByReviewForm_false() throws InterruptedException {
+    void existsByReviewForm_false() {
         // when
         boolean actual = reviewRepository.existsByReviewForm(savedReviewForm);
 

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/ReviewRepositoryTest.java
@@ -25,9 +25,8 @@ import com.reviewduck.member.repository.MemberRepository;
 import com.reviewduck.review.domain.Answer;
 import com.reviewduck.review.domain.Review;
 import com.reviewduck.review.domain.ReviewForm;
-import com.reviewduck.review.domain.ReviewFormQuestion;
-import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
 import com.reviewduck.review.dto.service.QuestionAnswerCreateDto;
+import com.reviewduck.review.service.ReviewFormQuestionCreateDto;
 
 @DataJpaTest
 @Import(JpaAuditingConfig.class)
@@ -230,5 +229,28 @@ public class ReviewRepositoryTest {
         );
 
         return reviewRepository.save(review);
+    }
+
+    @Test
+    @DisplayName("특정 회고 질문지로 만든 회고가 존재한다.")
+    void existsByReviewForm_true() throws InterruptedException {
+        // given
+        Review savedReview = saveReview(savedMember, savedReviewForm, false);
+
+        // when
+        boolean actual = reviewRepository.existsByReviewForm(savedReviewForm);
+
+        // then
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    @DisplayName("특정 회고 질문지로 만든 회고가 존재하지 않는다.")
+    void existsByReviewForm_false() throws InterruptedException {
+        // when
+        boolean actual = reviewRepository.existsByReviewForm(savedReviewForm);
+
+        // then
+        assertThat(actual).isFalse();
     }
 }

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/repository/TestReviewFormRepository.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/repository/TestReviewFormRepository.java
@@ -1,0 +1,13 @@
+package com.reviewduck.review.repository;
+
+
+import java.util.Optional;
+
+import org.springframework.data.repository.Repository;
+
+import com.reviewduck.review.domain.ReviewForm;
+
+public interface TestReviewFormRepository extends Repository<ReviewForm, Long> {
+
+    Optional<ReviewForm> findByCode(String code);
+}

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
@@ -24,6 +24,9 @@ import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.service.MemberService;
 import com.reviewduck.review.domain.ReviewForm;
 import com.reviewduck.review.domain.ReviewFormQuestion;
+import com.reviewduck.review.dto.controller.request.AnswerCreateRequest;
+import com.reviewduck.review.dto.controller.request.ReviewContentCreateRequest;
+import com.reviewduck.review.dto.controller.request.ReviewCreateRequest;
 import com.reviewduck.review.dto.controller.request.ReviewFormCreateRequest;
 import com.reviewduck.review.dto.controller.request.ReviewFormQuestionCreateRequest;
 import com.reviewduck.review.dto.controller.request.ReviewFormQuestionUpdateRequest;
@@ -43,6 +46,12 @@ public class ReviewFormServiceTest {
 
     @Autowired
     private ReviewFormService reviewFormService;
+
+    @Autowired
+    private ReviewFormQuestionService reviewFormQuestionService;
+
+    @Autowired
+    private ReviewService reviewService;
 
     @Autowired
     private TemplateService templateService;
@@ -502,8 +511,29 @@ public class ReviewFormServiceTest {
     class deleteByCode {
 
         @Test
-        @DisplayName("회고 폼을 삭제한다.")
-        void deleteReviewForm() throws InterruptedException {
+        @DisplayName("회고 폼을 삭제한다(생성한 회고 있는 상태).")
+        void deleteReviewForm_reviewExists() throws InterruptedException {
+            // given
+            ReviewForm savedReviewForm = saveReviewForm(member1);
+            String code = savedReviewForm.getCode();
+            ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(false, List.of(
+                new ReviewContentCreateRequest(1L, new AnswerCreateRequest("answer1")),
+                new ReviewContentCreateRequest(2L, new AnswerCreateRequest("answer2"))
+            ));
+            reviewService.save(member1, code, reviewCreateRequest);
+
+            // when
+            reviewFormService.deleteByCode(member1, code);
+
+            // then
+            assertThatThrownBy(() -> reviewFormService.findByCode(code))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("존재하지 않는 회고 폼입니다.");
+        }
+
+        @Test
+        @DisplayName("회고 폼을 삭제한다(생성한 회고 없는 상태).")
+        void deleteReviewForm_reviewNotExists() throws InterruptedException {
             // given
             ReviewForm savedReviewForm = saveReviewForm(member1);
             String code = savedReviewForm.getCode();


### PR DESCRIPTION
기존 delete를 deleteSoftly로 변경하고 
hard delete를 delete로 두었습니다. 
특정 ReviewForm으로 생성한 Review가 있는지 검증하는 메서드는 Data Jpa에서 method generating으로 제공하는 
existsByReviewForm을 사용하였습니다. 
내부 구현에서 해당 쿼리를 사용합니다. 
`select review_id from review where review_form_id=? limit 1;`