### PR TITLE
오버뷰 회고폼 캐싱 무효화 및 참여코드 정규식 버그 수정

### DIFF
--- a/frontend/src/constant/index.ts
+++ b/frontend/src/constant/index.ts
@@ -94,7 +94,7 @@ const REVIEW_FORM_TITLE_LENGTH = 100;
 const REVIEW_FORM_CODE_LENGTH = 8;
 
 const REGEX = {
-  REVIEW_FORM_CODE: `(?=.*[A-Za-z])(?=.*[0-9])[a-zA-Z0-9]{${REVIEW_FORM_CODE_LENGTH}}$`,
+  REVIEW_FORM_CODE: `^[a-zA-Z0-9]{${REVIEW_FORM_CODE_LENGTH}}$`,
   NICKNAME: '^[a-zA-Z가-힣ㄱ-ㅎ0-9]{2,10}$',
 };
 

--- a/frontend/src/service/@shared/hooks/queries/review/useCreate.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useCreate.ts
@@ -28,6 +28,7 @@ function useCreateReviewAnswer(
   return useMutation(reviewAPI.createAnswer, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW]);
+      queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW_FORM]);
     },
     ...mutationOptions,
   });

--- a/frontend/src/service/review/pages/ReviewOverviewPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/index.tsx
@@ -153,7 +153,7 @@ function ReviewOverViewPage() {
                 ))}
               </React.Fragment>
             ))}
-            <div ref={targetRef}></div>
+            <div ref={targetRef} />
             {isFetching && <ListView.Loading line={PAGE_OPTION.REVIEW_ITEM_SIZE} />}
           </ListView.Content>
 
@@ -196,11 +196,11 @@ function ReviewOverViewPage() {
                 {page.data.reviews.map(({ id, info: { creator }, questions }, index) => (
                   <SheetView.Answers
                     key={id}
-                    ref={
-                      displayMode === 'sheet' && index === PAGE_OPTION.REVIEW_ITEM_SIZE - 1
-                        ? targetRef
-                        : null
-                    }
+                    // ref={
+                    //   displayMode === 'sheet' && index === PAGE_OPTION.REVIEW_ITEM_SIZE - 1
+                    //     ? targetRef
+                    //     : null
+                    // }
                   >
                     <SheetView.Creator
                       socialId={creator.id}
@@ -216,6 +216,7 @@ function ReviewOverViewPage() {
               </React.Fragment>
             ))}
             {isFetching && <SheetView.Loading line={PAGE_OPTION.REVIEW_ITEM_SIZE} />}
+            <div ref={targetRef} />
           </SheetView.ReviewList>
         </SheetView>
       )}


### PR DESCRIPTION
- 오버뷰에서 회고 답변을 생성했을 때 회고폼 쿼리데이터도 무효화해줘야 함. 이 부분 수정함.
- 참여코드 정규식에서 숫자가 안 들어갈 수 있는데 숫자가 안 들어가면 예외로 핸들링하는 부분 수정함. 숫자만 또는 영어만 또는 숫자 영어 조합 세 가지 경우 다 가능하도록 수정
- 무한스크롤 target Ref 를 div 로 고정해두는 방식이 적용돼있지 않아 이 부분 추가함