### PR TITLE
유저페이지 추가 정보 보여주기 구현

### DIFF
--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -61,7 +61,7 @@ function PageRoutes() {
 
           <Route path={PAGE_LIST.REVIEW_FORM}>
             <Route index element={<SplitPages.ReviewFormEditorPage />} />
-            <Route path=":" element={<SplitPages.ReviewFormEditorPage />} />
+            <Route path=":reviewFormCode" element={<SplitPages.ReviewFormEditorPage />} />
           </Route>
         </Route>
       </Route>

--- a/frontend/src/api/user.transformer.ts
+++ b/frontend/src/api/user.transformer.ts
@@ -5,6 +5,8 @@ import {
   GetUserTemplatesResponse,
 } from 'types';
 
+import { getElapsedTimeText } from 'service/@shared/utils';
+
 export const transformUserReviews = (data: GetUserReviewAnswerResponse): UserArticleList => {
   const { numberOfReviews, isMine, reviews } = data;
 
@@ -16,6 +18,9 @@ export const transformUserReviews = (data: GetUserReviewAnswerResponse): UserArt
       reviewFormCode: review.reviewForm.code,
       title: review.reviewForm.title,
       reviewTitle: review.title,
+      updatedAt: getElapsedTimeText(review.updatedAt),
+      isPrivate: review.isPrivate,
+      likes: review.likes,
       contents: review.contents.map((content) => ({
         question: {
           id: content.question.id,
@@ -39,6 +44,7 @@ export const transformUserReviewForms = (data: GetUserReviewFormsResponse): User
     articleList: reviewForms.map((reviewForm) => ({
       reviewFormCode: reviewForm.code,
       title: reviewForm.title,
+      updatedAt: getElapsedTimeText(reviewForm.updatedAt),
       contents: reviewForm.questions.map((question) => ({
         question: {
           id: question.id,
@@ -59,6 +65,7 @@ export const transformUserTemplates = (data: GetUserTemplatesResponse): UserArti
     articleList: templates.map((template) => ({
       id: template.info.id,
       title: template.info.title,
+      updatedAt: getElapsedTimeText(template.info.updatedAt),
       contents: template.questions.map((question) => ({
         question: {
           id: question.id,

--- a/frontend/src/service/@shared/components/Questions/index.tsx
+++ b/frontend/src/service/@shared/components/Questions/index.tsx
@@ -1,4 +1,4 @@
-import { faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
+import { faLock, faPenToSquare, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
@@ -42,26 +42,26 @@ function CoverProfile({ socialId, image, title, description }: CoverProfileProps
 }
 
 interface TitleProps {
-  children?: string;
-}
-
-function Title({ children }: TitleProps) {
-  return (
-    <Text as="h1" className={styles.title} size={24} weight="bold">
-      {children}
-    </Text>
-  );
-}
-
-interface SubTitleProps {
   children: string;
+  isPrivate?: boolean;
+  subtitle?: string;
 }
 
-function SubTitle({ children }: SubTitleProps) {
+function Title({ children, isPrivate, subtitle }: TitleProps) {
   return (
-    <Text className={styles.subTitle} as="h3" size={16}>
-      {children}
-    </Text>
+    <FlexContainer className={styles.titleContainer}>
+      <FlexContainer direction="row" align="center" gap="medium">
+        <Text as="h1" className={styles.title} size={24} weight="bold">
+          {children}
+        </Text>
+        {isPrivate && <FontAwesomeIcon className={styles.lock} icon={faLock} />}
+      </FlexContainer>
+      {subtitle && (
+        <Text className={styles.subTitle} as="h3" size={16}>
+          {subtitle}
+        </Text>
+      )}
+    </FlexContainer>
   );
 }
 
@@ -151,13 +151,25 @@ function Reaction({ likeCount, onClickLike, onClickBookmark }: ReactionProps) {
   );
 }
 
+interface UpdatedTimeProps {
+  children: string;
+}
+
+function UpdatedTime({ children }: UpdatedTimeProps) {
+  return (
+    <Text className={styles.updatedAt} size={14}>
+      {children}
+    </Text>
+  );
+}
+
 const Questions = Object.assign(Container, {
   CoverProfile,
   Title,
-  SubTitle,
   EditButtons,
   Answer,
   Reaction,
+  UpdatedTime,
 });
 
 export default Questions;

--- a/frontend/src/service/@shared/components/Questions/styles.module.scss
+++ b/frontend/src/service/@shared/components/Questions/styles.module.scss
@@ -18,16 +18,23 @@
   }
 }
 
-.title {
-  padding: 1rem 0;
-  color: $THEME_COLOR_STATUS_PRIMARY_600;
-  line-height: 160%;
-}
-
-.sub-title {
-  padding-bottom: 1rem;
-  color: $THEME_COLOR_THEME_TEXT_400;
+.title-container {
   border-bottom: 1px solid $THEME_COLOR_STATUS_PRIMARY_100;
+
+  .title {
+    padding: 1rem 0;
+    color: $THEME_COLOR_STATUS_PRIMARY_600;
+    line-height: 160%;
+  }
+
+  .lock {
+    color: $THEME_COLOR_THEME_TEXT_150;
+  }
+
+  .sub-title {
+    padding-bottom: 1rem;
+    color: $THEME_COLOR_THEME_TEXT_400;
+  }
 }
 
 .answerContainer {
@@ -71,4 +78,8 @@
       color: $THEME_COLOR_STATUS_DANGER_400;
     }
   }
+}
+
+.updated-at {
+  color: $THEME_COLOR_THEME_TEXT_150;
 }

--- a/frontend/src/service/user/pages/ProfilePage/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/index.tsx
@@ -9,7 +9,7 @@ import { Tabs } from 'types';
 import useModal from 'common/hooks/useModal';
 import useSnackbar from 'common/hooks/useSnackbar';
 
-import { PaginationBar } from 'common/components';
+import { FlexContainer, PaginationBar } from 'common/components';
 
 import PageSuspense from 'common/components/PageSuspense';
 import { PaginationBarProps } from 'common/components/PaginationBar';
@@ -101,6 +101,7 @@ function ProfilePage() {
       icon: faTrash,
       title: `삭제 처리 되었습니다.`,
       description: '삭제된 정보는 복구할 수 없습니다.',
+      theme: 'warning',
     });
   };
 
@@ -166,11 +167,10 @@ function ProfilePage() {
                       : `${PAGE_LIST.REVIEW_OVERVIEW}/${article.reviewFormCode}`
                   }
                 >
-                  <Questions.Title>{article.title}</Questions.Title>
+                  <Questions.Title isPrivate={article.isPrivate} subtitle={article.reviewTitle}>
+                    {article.title}
+                  </Questions.Title>
                 </Link>
-                {article.reviewTitle && (
-                  <Questions.SubTitle>{article.reviewTitle}</Questions.SubTitle>
-                )}
                 <Questions.EditButtons
                   isVisible={userArticles.isMine}
                   onClickEdit={handleClickEdit(
@@ -189,11 +189,19 @@ function ProfilePage() {
                     {content.answer?.value}
                   </Questions.Answer>
                 ))}
-                <Questions.Reaction
-                  likeCount={0}
-                  onClickLike={() => null}
-                  onClickBookmark={() => null}
-                />
+                {currentTab === FILTER.USER_PROFILE_TAB.REVIEWS && (
+                  <FlexContainer direction="row" justify="space-between">
+                    <Questions.Reaction
+                      likeCount={article.likes || 0}
+                      onClickLike={() => null}
+                      onClickBookmark={() => null}
+                    />
+                    <Questions.UpdatedTime>{article.updatedAt}</Questions.UpdatedTime>
+                  </FlexContainer>
+                )}
+                {currentTab !== FILTER.USER_PROFILE_TAB.REVIEWS && (
+                  <Questions.UpdatedTime>{article.updatedAt}</Questions.UpdatedTime>
+                )}
               </Questions>
             </div>
           ))}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -15,6 +15,9 @@ export interface UserArticleList {
     reviewFormCode?: string;
     title: string;
     reviewTitle?: string;
+    updatedAt: string;
+    isPrivate?: boolean;
+    likes?: number;
 
     contents: Array<{
       question: ServerQuestionRequireId;
@@ -31,6 +34,7 @@ export interface GetUserReviewAnswerResponse {
     title: string;
     isPrivate: boolean;
     updatedAt: number;
+    likes: number;
     contents: Array<{
       question: ServerQuestionRequireId;
       answer: ServerAnswerRequireId;


### PR DESCRIPTION
- 유저페이지 회고 답변 좋아요 api 연결
- 회고답변제목 구조 개선
- 업데이트 시간 추가

- 실수인 것 같은데 PageRoutes 에서 reviewFormCode 를 받지 않아서 회고폼에디터페이지 접근이 불가한 버그가 있었는데 추가로 수정했습니다!

### 유저페이지 회고 답변
<img width="770" alt="스크린샷 2022-10-07 오후 7 03 59" src="https://user-images.githubusercontent.com/51396282/194528896-b93f0435-9c26-43db-b2db-c4e6dedaf514.png">


### 유저페이지 질문지, 템플릿
<img width="773" alt="스크린샷 2022-10-07 오후 7 01 05" src="https://user-images.githubusercontent.com/51396282/194528354-99434f50-de85-4752-b644-1957d0764dfd.png">
