### PR TITLE
페이지네이션바 버그 수정

### DIFF
--- a/frontend/src/common/components/PaginationBar/index.tsx
+++ b/frontend/src/common/components/PaginationBar/index.tsx
@@ -34,7 +34,7 @@ function PaginationBar({
     const currentPageStack = Math.ceil(focusedPage / visiblePageButtonLength);
 
     const pageButtonLength =
-      totalPageStack === currentPageStack && totalPageLength !== visiblePageButtonLength
+      totalPageStack === currentPageStack && totalPageLength % visiblePageButtonLength !== 0
         ? totalPageLength % visiblePageButtonLength
         : visiblePageButtonLength;
 

--- a/frontend/src/common/components/PaginationBar/index.tsx
+++ b/frontend/src/common/components/PaginationBar/index.tsx
@@ -1,6 +1,8 @@
-import { HTMLAttributes, useMemo } from 'react';
+import { HTMLAttributes, useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 
 import cn from 'classnames';
+import { FILTER } from 'constant';
 
 import styles from './styles.module.scss';
 
@@ -24,6 +26,7 @@ function PaginationBar({
   ...args
 }: PaginationBarProps) {
   const totalPageLength = Math.ceil(totalItemCount / itemCountInPage);
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const isFirstPage = focusedPage === 1;
   const isLastPage = focusedPage === totalPageLength;
@@ -55,6 +58,16 @@ function PaginationBar({
   const handleClickPageButton = (pageNumber: number) => () => {
     onClickPageButton(pageNumber);
   };
+
+  useEffect(() => {
+    if (focusedPage > totalPageLength) {
+      setSearchParams({
+        tab: searchParams.get('tab') || FILTER.USER_PROFILE_TAB.REVIEWS,
+        page: String(totalPageLength),
+      });
+      window.scrollTo(0, 0);
+    }
+  }, [focusedPage, totalItemCount]);
 
   if (totalItemCount === 0) return <></>;
 

--- a/frontend/src/service/template/pages/TemplateListPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateListPage/index.tsx
@@ -56,8 +56,7 @@ function TemplateListPage() {
   const handleClickPagination = (pageNumber: number) => {
     if (searchQueryString) {
       setSearchParam({ search: searchQueryString, page: String(pageNumber) });
-    }
-    if (filterQueryString) {
+    } else {
       setSearchParam({ sort: currentTab, page: String(pageNumber) });
     }
     window.scrollTo(0, 0);

--- a/frontend/src/service/user/pages/ProfilePage/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/index.tsx
@@ -240,7 +240,7 @@ function ProfilePage() {
             </div>
           ))}
 
-          <ArticleList.NoArticleResult totalNumber={articlesPages.totalNumber}>
+          <ArticleList.NoArticleResult totalNumber={articles.length}>
             {`${subjectTitle[currentTab]}가(이) 없습니다.`}
           </ArticleList.NoArticleResult>
 


### PR DESCRIPTION
## 원인
prop으로 받아오는 visiblePageButtonLength 가 5라고 가정했으 때 5로 나누어떨어지는 부분을 전부 다 처리해주지 못해서 발생한 버그였습니다.

## 해결
나누어 떨어지는 엣지케이스 경우를 전부 추가하도록 조건을 수정해서 해결했습니다.

[4e70080](https://github.com/woowacourse-teams/2022-review-duck/pull/559/commits/4e7008023f294df9ecee0b4a1b0d52e7426998df)

## 추가
해당 버그를 수정하는 과정에서 TemplateListPage 에서 페이지네이션바가 작동하지 않는 버그를 발견해서 추가로 수정했습니다.

```js
  const currentTab = isInclude(Object.values(FILTER.TEMPLATE_TAB), filterQueryString)
    ? filterQueryString
    : FILTER.TEMPLATE_TAB.LATEST;
```

위 스니펫에서 보다시피 페이지에서 `currentTab` 의 기본값을 LATEST 상수로 정해놓기 때문에 해당 변수를 사용해서 분기할 수 없었습니다.

그래서 search 쿼리가 없는 경우는 기존에 작동하던 방식대로 정렬기준은 유지하고 페이지넘버만 바꾸는 쿼리를 set 하는 것으로 수정했습니다.

커밋 기록 참고바랍니다.

[4c64e87](https://github.com/woowacourse-teams/2022-review-duck/pull/559/commits/4c64e87f41ed57be3336e3745ff1d9af7a5fb584)

## 리다이렉트 기능 추가
### 버그
페이지네이션 컴포넌트에서 잘못된 url 정보고 예를 들어 `page=9999` 처럼 없는 정보가 들어올 경우 예외가 처리되지 않는 버그가 있었습니다.

### 해결

컴포넌트 내부에서 item의 총 개수를 계산하여 계산된 마지막페이지보다 높은 경우 마지막 페이지로 리다이렉트 하도록 수정했습니다.

또한, 한 페이지 안에서 (예, 프로필 페이지) 아이템을 하나 하나 삭제하다보면 결국엔 그 페이지 내에 아이템이 없는 경우가 생기는데 이 부분도 사용자 경험에 좋지 못한 버그입니다.

그래서 아이템이 삭제될때도 위와 같이 마지막 페이지로 리다이렉트 해야 하는지 여부를 판단하도록 수정해서 해결했습니다.

[커밋 내용](https://github.com/woowacourse-teams/2022-review-duck/pull/559/commits/3e0953bedaca5bc8e380a5995c576030dbb26d36)