### PR TITLE
검색 후 리다이렉트 되는 버그 수정

### DIFF
--- a/frontend/src/api/review.api.ts
+++ b/frontend/src/api/review.api.ts
@@ -1,6 +1,6 @@
 import * as ReviewType from '../types/review';
 
-import { API_URI, PAGE_OPTION } from '../constant';
+import { API_URI, FILTER, PAGE_OPTION } from '../constant';
 import * as transformer from './review.transformer';
 import axiosInstance from 'api/config/axiosInstance';
 
@@ -48,7 +48,7 @@ export const getPublicAnswer = async ({
   filter = 'trend',
 }: GetReviewPublicAnswerRequest): Promise<ReviewType.ReviewPublicAnswerList> => {
   const { data } = await axiosInstance.get(
-    `${API_URI.REVIEW.GET_PUBLIC_ANSWER}?page=${pageNumber}&size=${size}&sort=${filter}`,
+    `${API_URI.REVIEW.GET_PUBLIC_ANSWER}?${FILTER.PAGE}=${pageNumber}&${FILTER.SIZE}=${size}&${FILTER.SORT}=${filter}`,
   );
 
   return transformer.transformPublicAnswer(data);

--- a/frontend/src/api/template.api.ts
+++ b/frontend/src/api/template.api.ts
@@ -18,7 +18,7 @@ export const getTemplates = async (
   itemCount = PAGE_OPTION.TEMPLATE_ITEM_SIZE,
 ) => {
   const { data } = await axiosInstance.get<GetTemplatesResponse>(
-    `${API_URI.TEMPLATE.GET_TEMPLATES}?page=${pageNumber}&size=${itemCount}&sort=${filter}`,
+    `${API_URI.TEMPLATE.GET_TEMPLATES}?${FILTER.PAGE}=${pageNumber}&${FILTER.SIZE}=${itemCount}&${FILTER.SORT}=${filter}`,
   );
 
   return data;
@@ -30,7 +30,7 @@ export const getSearchTemplates = async (
   itemCount = PAGE_OPTION.TEMPLATE_ITEM_SIZE,
 ) => {
   const { data } = await axiosInstance.get<GetTemplatesResponse>(
-    `${API_URI.TEMPLATE.GET_SEARCH_TEMPLATES}?query=${search}&page=${pageNumber}&size=${itemCount}`,
+    `${API_URI.TEMPLATE.GET_SEARCH_TEMPLATES}?query=${search}&${FILTER.PAGE}=${pageNumber}&${FILTER.SIZE}=${itemCount}`,
   );
 
   return data;

--- a/frontend/src/api/user.api.ts
+++ b/frontend/src/api/user.api.ts
@@ -1,6 +1,6 @@
 import * as UserType from '../types';
 
-import { API_URI, PAGE_OPTION } from '../constant';
+import { API_URI, FILTER, PAGE_OPTION } from '../constant';
 import * as transformer from './user.transformer';
 import axiosInstance from 'api/config/axiosInstance';
 
@@ -9,7 +9,7 @@ export const getUserReviewAnswers = async (
   pageNumber: number,
 ): Promise<UserType.UserArticleList> => {
   const { data } = await axiosInstance.get(
-    `${API_URI.USER.GET_REVIEW_ANSWERS}?member=${socialId}&page=${pageNumber}&size=${PAGE_OPTION.REVIEW_ITEM_SIZE}`,
+    `${API_URI.USER.GET_REVIEW_ANSWERS}?member=${socialId}&${FILTER.PAGE}=${pageNumber}&${FILTER.SIZE}=${PAGE_OPTION.REVIEW_ITEM_SIZE}`,
   );
 
   return transformer.transformUserReviews(data);
@@ -20,7 +20,7 @@ export const getUserReviewForms = async (
   pageNumber: number,
 ): Promise<UserType.UserArticleList> => {
   const { data } = await axiosInstance.get(
-    `${API_URI.USER.GET_REVIEW_FORMS}?member=${socialId}&page=${pageNumber}&size=${PAGE_OPTION.REVIEW_ITEM_SIZE}`,
+    `${API_URI.USER.GET_REVIEW_FORMS}?member=${socialId}&${FILTER.PAGE}=${pageNumber}&${FILTER.SIZE}=${PAGE_OPTION.REVIEW_ITEM_SIZE}`,
   );
 
   return transformer.transformUserReviewForms(data);
@@ -31,7 +31,7 @@ export const getUserTemplates = async (
   pageNumber: number,
 ): Promise<UserType.UserArticleList> => {
   const { data } = await axiosInstance.get(
-    `${API_URI.USER.GET_TEMPLATES(socialId)}&page=${pageNumber}&size=${
+    `${API_URI.USER.GET_TEMPLATES(socialId)}&${FILTER.PAGE}=${pageNumber}&${FILTER.SIZE}=${
       PAGE_OPTION.USER_TEMPLATE_SIZE
     }`,
   );

--- a/frontend/src/common/components/PaginationBar/index.tsx
+++ b/frontend/src/common/components/PaginationBar/index.tsx
@@ -1,36 +1,42 @@
-import { HTMLAttributes, useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useMemo } from 'react';
 
 import cn from 'classnames';
-import { FILTER } from 'constant';
 
 import styles from './styles.module.scss';
 
 import FlexContainer from '../FlexContainer';
 
-export interface PaginationBarProps extends HTMLAttributes<HTMLDivElement> {
-  visiblePageButtonLength: number;
+export interface PaginationBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  visiblePageButtonLength?: number;
   itemCountInPage: number;
   totalItemCount: number;
-  focusedPage: number;
+  focusedPage?: number;
+  scrollReset?: boolean;
   onClickPageButton: (pageNumber: number) => void;
 }
 
 function PaginationBar({
   className,
-  visiblePageButtonLength,
+  visiblePageButtonLength = 5,
   itemCountInPage,
   totalItemCount,
-  focusedPage,
+  focusedPage = 1,
+  scrollReset = true,
   onClickPageButton,
   ...args
 }: PaginationBarProps) {
   const totalPageLength = Math.ceil(totalItemCount / itemCountInPage);
-  const [searchParams, setSearchParams] = useSearchParams();
 
   const isFirstPage = focusedPage === 1;
   const isLastPage = focusedPage === totalPageLength;
-  const isCurrentPage = (pageNumber: number) => focusedPage === pageNumber;
+
+  useEffect(
+    function resetPreviousScroll() {
+      if (!scrollReset) return;
+      window.scrollTo(0, 0);
+    },
+    [scrollReset, focusedPage],
+  );
 
   const currentPageNumbers: number[] = useMemo(() => {
     const totalPageStack = Math.ceil(totalPageLength / visiblePageButtonLength);
@@ -55,18 +61,13 @@ function PaginationBar({
     );
   }, [totalPageLength, visiblePageButtonLength, focusedPage]);
 
+  if (totalItemCount === 0) return <></>;
+
+  const isFocusedPage = (pageNumber: number) => focusedPage === pageNumber;
+
   const handleClickPageButton = (pageNumber: number) => () => {
     onClickPageButton(pageNumber);
   };
-
-  useEffect(() => {
-    if (focusedPage > totalPageLength) {
-      setSearchParams({});
-      window.scrollTo(0, 0);
-    }
-  }, [focusedPage, totalItemCount]);
-
-  if (totalItemCount === 0) return <></>;
 
   return (
     <FlexContainer
@@ -95,10 +96,10 @@ function PaginationBar({
           <button
             key={pageNumber}
             className={cn(styles.pageButton, {
-              [styles.currentPage]: isCurrentPage(pageNumber),
+              [styles.currentPage]: isFocusedPage(pageNumber),
             })}
             onClick={handleClickPageButton(pageNumber)}
-            disabled={isCurrentPage(pageNumber)}
+            disabled={isFocusedPage(pageNumber)}
           >
             {pageNumber}
           </button>
@@ -122,10 +123,5 @@ function PaginationBar({
     </FlexContainer>
   );
 }
-
-PaginationBar.defaultProps = {
-  visiblePageButtonLength: 5,
-  focusedPage: 1,
-};
 
 export default PaginationBar;

--- a/frontend/src/common/components/PaginationBar/index.tsx
+++ b/frontend/src/common/components/PaginationBar/index.tsx
@@ -61,10 +61,7 @@ function PaginationBar({
 
   useEffect(() => {
     if (focusedPage > totalPageLength) {
-      setSearchParams({
-        tab: searchParams.get('tab') || FILTER.USER_PROFILE_TAB.REVIEWS,
-        page: String(totalPageLength),
-      });
+      setSearchParams({});
       window.scrollTo(0, 0);
     }
   }, [focusedPage, totalItemCount]);

--- a/frontend/src/constant/index.ts
+++ b/frontend/src/constant/index.ts
@@ -90,6 +90,10 @@ const FILTER = {
     LIST: 'list',
     SHEET: 'sheet',
   },
+  PAGE: 'page',
+  SORT: 'sort',
+  SEARCH: 'search',
+  SIZE: 'size',
 } as const;
 
 const REVIEW_FORM_TITLE_LENGTH = 100;
@@ -119,7 +123,7 @@ const API_URI = {
     GET_FORM: (reviewFormCode: string) => `/api/review-forms/${reviewFormCode}`,
     GET_ANSWER: (reviewId: numberString) => `/api/reviews/${reviewId}`,
     GET_FORM_ANSWER: (reviewFormCode: string, display: string, page?: number, size?: number) =>
-      `/api/review-forms/${reviewFormCode}/reviews?displayType=${display}&page=${page}&size=${size}`,
+      `/api/review-forms/${reviewFormCode}/reviews?displayType=${display}&${FILTER.PAGE}=${page}&${FILTER.SIZE}=${size}`,
     GET_PUBLIC_ANSWER: '/api/reviews/public',
 
     CREATE_FORM: '/api/review-forms',
@@ -142,7 +146,7 @@ const API_URI = {
   },
   TEMPLATE: {
     GET_TEMPLATES: '/api/templates/all',
-    GET_SEARCH_TEMPLATES: '/api/templates/search',
+    GET_SEARCH_TEMPLATES: `/api/templates/${FILTER.SEARCH}`,
     GET_TEMPLATE: (templateId: numberString) => `/api/templates/${templateId}`,
 
     CREATE_FORM: (templateId: numberString) => `/api/templates/${templateId}/review-forms`,

--- a/frontend/src/service/@shared/layout/MainLayout/Header.tsx
+++ b/frontend/src/service/@shared/layout/MainLayout/Header.tsx
@@ -45,6 +45,7 @@ function Header() {
     if (search.length > 0) {
       navigate(`${PAGE_LIST.TEMPLATE_LIST}?search=${search}`);
     }
+    setSearch('');
   };
 
   return (

--- a/frontend/src/service/@shared/layout/MainLayout/Header.tsx
+++ b/frontend/src/service/@shared/layout/MainLayout/Header.tsx
@@ -10,7 +10,7 @@ import {
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { GITHUB_OAUTH_LOGIN_URL, MODAL_LIST, PAGE_LIST } from 'constant';
+import { FILTER, GITHUB_OAUTH_LOGIN_URL, MODAL_LIST, PAGE_LIST } from 'constant';
 
 import useAuth from 'service/@shared/hooks/useAuth';
 
@@ -43,7 +43,7 @@ function Header() {
   const handleSubmitSearhTemplate = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     if (search.length > 0) {
-      navigate(`${PAGE_LIST.TEMPLATE_LIST}?search=${search}`);
+      navigate(`${PAGE_LIST.TEMPLATE_LIST}?${FILTER.SEARCH}=${search}`);
     }
     setSearch('');
   };
@@ -63,7 +63,7 @@ function Header() {
             value={search}
             onChange={handleSearchChange}
           />
-          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?search=${search}`}>
+          <Link to={`${PAGE_LIST.TEMPLATE_LIST}?${FILTER.SEARCH}=${search}`}>
             <FontAwesomeIcon className={styles.searchIcon} icon={faSearch} />
           </Link>
         </form>

--- a/frontend/src/service/review/pages/ReviewTimelinePage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/index.tsx
@@ -23,7 +23,7 @@ import { updateReviewLike } from 'api/review.api';
 function ReviewTimelinePage() {
   const [searchParam] = useSearchParams();
 
-  const filterQueryString = searchParam.get('sort');
+  const filterQueryString = searchParam.get(FILTER.SORT);
   const currentTab = isInclude(Object.values(FILTER.TEMPLATE_TAB), filterQueryString)
     ? filterQueryString
     : FILTER.TEMPLATE_TAB.LATEST;

--- a/frontend/src/service/review/pages/ReviewTimelinePage/view/SideMenu/index.tsx
+++ b/frontend/src/service/review/pages/ReviewTimelinePage/view/SideMenu/index.tsx
@@ -4,7 +4,7 @@ import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import cn from 'classnames';
-import { PAGE_LIST } from 'constant';
+import { FILTER, PAGE_LIST } from 'constant';
 import { TimelineFilterType } from 'types';
 
 import { FlexContainer, Text } from 'common/components';
@@ -56,7 +56,7 @@ interface MenuProps {
 
 function Menu({ isCurrentTab, filter, icon, children }: MenuProps) {
   return (
-    <Link to={`${PAGE_LIST.TIMELINE}?sort=${filter}`}>
+    <Link to={`${PAGE_LIST.TIMELINE}?${FILTER.SORT}=${filter}`}>
       <li className={cn(styles.menu, { [styles.focus]: isCurrentTab })}>
         <FontAwesomeIcon icon={icon} /> {children}
       </li>

--- a/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
@@ -30,7 +30,7 @@ function TemplateDetailPage() {
   const [searchParam] = useSearchParams();
   const templateMutation = useTemplateMutations();
 
-  const filterQueryString = searchParam.get('sort');
+  const filterQueryString = searchParam.get(FILTER.SORT);
   const currentTab = isInclude(Object.values(FILTER.TEMPLATE_TAB), filterQueryString)
     ? filterQueryString
     : FILTER.TEMPLATE_TAB.LATEST;
@@ -45,7 +45,7 @@ function TemplateDetailPage() {
   const { info: templateInfo, creator: templateCreator, ...template } = queries.template;
 
   const handleTemplateView = (id: number) => () => {
-    navigate(`${PAGE_LIST.TEMPLATE_DETAIL}/${id}?sort=${currentTab}`);
+    navigate(`${PAGE_LIST.TEMPLATE_DETAIL}/${id}?${FILTER.SORT}=${currentTab}`);
   };
 
   const handleStartReview = () => {
@@ -134,7 +134,7 @@ function TemplateDetailPage() {
 
           <Content.MoreButtons
             onClickCreateTemplate={handleLinkPage(PAGE_LIST.TEMPLATE_FORM)}
-            onClickList={handleLinkPage(`${PAGE_LIST.TEMPLATE_LIST}?sort=${currentTab}`)}
+            onClickList={handleLinkPage(`${PAGE_LIST.TEMPLATE_LIST}?${FILTER.SORT}=${currentTab}`)}
           />
         </Content>
       </LayoutContainer>

--- a/frontend/src/service/template/pages/TemplateListPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateListPage/index.tsx
@@ -25,11 +25,11 @@ function TemplateListPage() {
   const [searchParam, setSearchParam] = useSearchParams();
   const navigate = useNavigate();
 
-  const pageNumberParams = searchParam.get('page');
+  const pageNumberParams = searchParam.get(FILTER.PAGE);
   const pageNumber = isNumberString(pageNumberParams) ? Number(pageNumberParams) : 1;
 
-  const filterQueryString = searchParam.get('sort');
-  const searchQueryString = searchParam.get('search') || '';
+  const filterQueryString = searchParam.get(FILTER.SORT);
+  const searchQueryString = searchParam.get(FILTER.SEARCH) || '';
 
   const currentTab = isInclude(Object.values(FILTER.TEMPLATE_TAB), filterQueryString)
     ? filterQueryString
@@ -42,11 +42,11 @@ function TemplateListPage() {
   );
 
   const handleTemplateView = (id: number) => () => {
-    navigate(`${PAGE_LIST.TEMPLATE_DETAIL}/${id}?sort=${currentTab}`);
+    navigate(`${PAGE_LIST.TEMPLATE_DETAIL}/${id}?${FILTER.SORT}=${currentTab}`);
   };
 
   const handleChangeSortList = (query: TemplateFilterType) => () => {
-    navigate(`${PAGE_LIST.TEMPLATE_LIST}?sort=${query}`);
+    navigate(`${PAGE_LIST.TEMPLATE_LIST}?${FILTER.SORT}=${query}`);
   };
 
   const handleMoveCreateTemplate = () => {

--- a/frontend/src/service/template/pages/TemplateListPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateListPage/index.tsx
@@ -81,32 +81,39 @@ function TemplateListPage() {
         <Filter.MoreButtons onClickCreate={handleMoveCreateTemplate} />
       </Filter>
 
-      <div className={styles.templateContainer}>
-        {templates.map(({ info, creator }) => (
-          <TemplateCard key={info.id} className={styles.card} onClick={handleTemplateView(info.id)}>
-            <TemplateCard.Tag usedCount={info.usedCount} />
-            <TemplateCard.Title>{info.title}</TemplateCard.Title>
-            <TemplateCard.UpdatedAt>{getElapsedTimeText(info.updatedAt)}</TemplateCard.UpdatedAt>
-            <TemplateCard.Description>{info.description}</TemplateCard.Description>
+      {numberOfTemplates === 0 ? (
+        <NoResult>템플릿이 없습니다.</NoResult>
+      ) : (
+        <div className={styles.templateContainer}>
+          {templates.map(({ info, creator }) => (
+            <TemplateCard
+              key={info.id}
+              className={styles.card}
+              onClick={handleTemplateView(info.id)}
+            >
+              <TemplateCard.Tag usedCount={info.usedCount} />
+              <TemplateCard.Title>{info.title}</TemplateCard.Title>
+              <TemplateCard.UpdatedAt>{getElapsedTimeText(info.updatedAt)}</TemplateCard.UpdatedAt>
+              <TemplateCard.Description>{info.description}</TemplateCard.Description>
 
-            <TemplateCard.Profile
-              profileUrl={creator.profileUrl}
-              nickname={creator.nickname}
-              socialNickname={creator.socialNickname}
-            />
-          </TemplateCard>
-        ))}
+              <TemplateCard.Profile
+                profileUrl={creator.profileUrl}
+                nickname={creator.nickname}
+                socialNickname={creator.socialNickname}
+              />
+            </TemplateCard>
+          ))}
 
-        <PaginationBar
-          className={styles.pagination}
-          visiblePageButtonLength={PAGE_OPTION.TEMPLATE_BUTTON_LENGTH}
-          itemCountInPage={PAGE_OPTION.TEMPLATE_ITEM_SIZE}
-          totalItemCount={numberOfTemplates}
-          focusedPage={Number(pageNumber)}
-          onClickPageButton={handleClickPagination}
-        />
-      </div>
-      {numberOfTemplates === 0 && <NoResult>템플릿이 없습니다.</NoResult>}
+          <PaginationBar
+            className={styles.pagination}
+            visiblePageButtonLength={PAGE_OPTION.TEMPLATE_BUTTON_LENGTH}
+            itemCountInPage={PAGE_OPTION.TEMPLATE_ITEM_SIZE}
+            totalItemCount={numberOfTemplates}
+            focusedPage={Number(pageNumber)}
+            onClickPageButton={handleClickPagination}
+          />
+        </div>
+      )}
     </LayoutContainer>,
   );
 }

--- a/frontend/src/service/user/pages/ProfilePage/index.tsx
+++ b/frontend/src/service/user/pages/ProfilePage/index.tsx
@@ -38,8 +38,8 @@ function ProfilePage() {
     ? currentTabParam
     : FILTER.USER_PROFILE_TAB.REVIEWS;
 
-  const pageNumber = isNumberString(searchParams.get('page'))
-    ? Number(searchParams.get('page'))
+  const pageNumber = isNumberString(searchParams.get(FILTER.PAGE))
+    ? Number(searchParams.get(FILTER.PAGE))
     : 1;
 
   const pageQueries = useProfilePage(currentTab, socialId, pageNumber);


### PR DESCRIPTION
### 원인
검색 후 TemplateListPage로 이동 후 최초에 templates 디폴트 값에서 numberOfTemplates 가 0 이기 때문에 PaginationBar 컴포넌트 내부 예외 로직으로 들어가게 됩니다.

해당 로직 안에서 리다이렉트를 하는데 이 때 `page=0` 으로 가기 때문에 네트워크 에러가 발생했습니다.

### 해결
numberOfTemplates 가 0인 경우 결과없음을 먼저 렌더링하고 PaginationBar 컴포넌트를 렌더링하지 않도록 수정했습니다.

### 추가
url FILTER 로직에 사용되는 문자열들을 전부 상수로 변경 및 적용했습니다. `FILTER` 상수 안에 추가했습니다. [해당 커밋](https://github.com/woowacourse-teams/2022-review-duck/pull/569/commits/7ec08854c76ff62e1ffe2f176f0e3819ba3e3878)