### PR TITLE
각종 링크 버그 및 리팩토링 진행

### DIFF
--- a/frontend/src/PageRoutes.tsx
+++ b/frontend/src/PageRoutes.tsx
@@ -71,7 +71,7 @@ function PageRoutes() {
 
         <Route path={PAGE_LIST.REVIEW}>
           <Route
-            index
+            path=":reviewFormCode"
             element={<Page title="회고 작성" component={lazy.ReviewAnswerEditorPage} permission={PERMISSION.LOGIN_USER} />}
           />
           <Route

--- a/frontend/src/service/@shared/hooks/queries/auth/useCreate.ts
+++ b/frontend/src/service/@shared/hooks/queries/auth/useCreate.ts
@@ -1,12 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
 import { authAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { CreateRefreshResponse, UseCustomMutationOptions } from 'types';
 
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import queryClient from 'api/config/queryClient';
 
 function useCreateRefreshToken(mutationOptions?: UseCustomMutationOptions<CreateRefreshResponse>) {
-  const queryClient = useQueryClient();
-
   return useMutation(authAPI.createRefreshToken, {
     onSettled: () => {
       queryClient.refetchQueries([QUERY_KEY.DATA.AUTH, QUERY_KEY.API.GET_ACCESS_TOKEN]);

--- a/frontend/src/service/@shared/hooks/queries/auth/useDelete.ts
+++ b/frontend/src/service/@shared/hooks/queries/auth/useDelete.ts
@@ -1,12 +1,12 @@
+import { useMutation } from '@tanstack/react-query';
+
 import { authAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { UseCustomMutationOptions } from 'types';
 
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import queryClient from 'api/config/queryClient';
 
 function useDeleteRefreshToken(mutationOptions?: UseCustomMutationOptions<null>) {
-  const queryClient = useQueryClient();
-
   return useMutation(authAPI.deleteRefreshToken, {
     onSettled: () => {
       queryClient.refetchQueries([QUERY_KEY.DATA.AUTH]);

--- a/frontend/src/service/@shared/hooks/queries/review/useCreate.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useCreate.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { reviewAPI } from 'api';
 import { QUERY_KEY } from 'constant';
@@ -9,9 +9,9 @@ import {
   CreateFormByTemplateResponse,
 } from 'types';
 
-function useCreateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateReviewFormResponse>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useCreateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateReviewFormResponse>) {
   return useMutation(reviewAPI.createForm, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW_FORM]);
@@ -23,8 +23,6 @@ function useCreateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateRe
 function useCreateReviewAnswer(
   mutationOptions?: UseCustomMutationOptions<UpdateReviewAnswerResponse>,
 ) {
-  const queryClient = useQueryClient();
-
   return useMutation(reviewAPI.createAnswer, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW]);
@@ -37,8 +35,6 @@ function useCreateReviewAnswer(
 function useCreateFormByTemplate(
   mutationOptions?: UseCustomMutationOptions<CreateFormByTemplateResponse>,
 ) {
-  const queryClient = useQueryClient();
-
   return useMutation(reviewAPI.createFormByTemplate, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW]);

--- a/frontend/src/service/@shared/hooks/queries/review/useDelete.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useDelete.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { reviewAPI } from 'api';
 import { QUERY_KEY } from 'constant';
@@ -8,9 +8,9 @@ import {
   UseCustomMutationOptions,
 } from 'types';
 
-function useDeleteReviewForm(mutationOptions?: UseCustomMutationOptions<DeleteReviewFormResponse>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useDeleteReviewForm(mutationOptions?: UseCustomMutationOptions<DeleteReviewFormResponse>) {
   return useMutation(reviewAPI.deleteForm, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW]);
@@ -23,8 +23,6 @@ function useDeleteReviewForm(mutationOptions?: UseCustomMutationOptions<DeleteRe
 function useDeleteReviewAnswer(
   mutationOptions?: UseCustomMutationOptions<DeleteReviewAnswerResponse>,
 ) {
-  const queryClient = useQueryClient();
-
   return useMutation(reviewAPI.deleteAnswer, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW]);

--- a/frontend/src/service/@shared/hooks/queries/review/useUpdate.ts
+++ b/frontend/src/service/@shared/hooks/queries/review/useUpdate.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { reviewAPI } from 'api';
 import { QUERY_KEY } from 'constant';
@@ -8,9 +8,9 @@ import {
   UseCustomMutationOptions,
 } from 'types';
 
-function useUpdateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateReviewFormResponse>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useUpdateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateReviewFormResponse>) {
   return useMutation(reviewAPI.updateForm, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW_FORM]);
@@ -23,8 +23,6 @@ function useUpdateReviewForm(mutationOptions?: UseCustomMutationOptions<UpdateRe
 function useUpdateReviewAnswer(
   mutationOptions?: UseCustomMutationOptions<UpdateReviewAnswerResponse>,
 ) {
-  const queryClient = useQueryClient();
-
   return useMutation(reviewAPI.updateAnswer, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.REVIEW]);

--- a/frontend/src/service/@shared/hooks/queries/template/useCreate.ts
+++ b/frontend/src/service/@shared/hooks/queries/template/useCreate.ts
@@ -1,12 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { templateAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { CreateFormResponse, UseCustomMutationOptions, CreateTemplateResponse } from 'types';
 
-function useCreateForm(mutationOptions?: UseCustomMutationOptions<CreateFormResponse>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useCreateForm(mutationOptions?: UseCustomMutationOptions<CreateFormResponse>) {
   return useMutation(templateAPI.createForm, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.TEMPLATE]);
@@ -16,8 +16,6 @@ function useCreateForm(mutationOptions?: UseCustomMutationOptions<CreateFormResp
 }
 
 function useCreateTemplate(mutationOptions?: UseCustomMutationOptions<CreateTemplateResponse>) {
-  const queryClient = useQueryClient();
-
   return useMutation(templateAPI.createTemplate, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.TEMPLATE, QUERY_KEY.API.GET_USER_TEMPLATES]);

--- a/frontend/src/service/@shared/hooks/queries/template/useDelete.ts
+++ b/frontend/src/service/@shared/hooks/queries/template/useDelete.ts
@@ -1,12 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { templateAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { UseCustomMutationOptions } from 'types';
 
-function useDeleteTemplate(mutationOptions?: UseCustomMutationOptions<null>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useDeleteTemplate(mutationOptions?: UseCustomMutationOptions<null>) {
   return useMutation(templateAPI.deleteTemplate, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.TEMPLATE]);

--- a/frontend/src/service/@shared/hooks/queries/template/useMutations.ts
+++ b/frontend/src/service/@shared/hooks/queries/template/useMutations.ts
@@ -1,12 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { templateAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { UseCustomMutationOptions } from 'types';
 
-function useTemplateMutation(mutationOptions: UseCustomMutationOptions<unknown> = {}) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useTemplateMutation(mutationOptions: UseCustomMutationOptions<unknown> = {}) {
   const invalidateQueries = () => {
     queryClient.invalidateQueries([QUERY_KEY.DATA.TEMPLATE]);
   };

--- a/frontend/src/service/@shared/hooks/queries/template/useUpdate.ts
+++ b/frontend/src/service/@shared/hooks/queries/template/useUpdate.ts
@@ -1,12 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { templateAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { UseCustomMutationOptions } from 'types';
 
-function useUpdateTemplate(mutationOptions?: UseCustomMutationOptions<null>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useUpdateTemplate(mutationOptions?: UseCustomMutationOptions<null>) {
   return useMutation(templateAPI.updateTemplate, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.TEMPLATE]);

--- a/frontend/src/service/@shared/hooks/queries/user/useUpdate.ts
+++ b/frontend/src/service/@shared/hooks/queries/user/useUpdate.ts
@@ -1,14 +1,15 @@
-import { userAPI } from 'api';
-import { UseCustomMutationOptions, UpdateProfileResponse } from 'types';
-
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { userAPI } from 'api';
+import { QUERY_KEY } from 'constant';
+import { UseCustomMutationOptions, UpdateProfileResponse } from 'types';
 
 function useUpdateProfile(mutationOptions?: UseCustomMutationOptions<UpdateProfileResponse>) {
   const queryClient = useQueryClient();
 
   return useMutation(userAPI.updateProfile, {
     onSuccess: () => {
-      queryClient.invalidateQueries();
+      queryClient.invalidateQueries([QUERY_KEY.DATA.USER, QUERY_KEY.API.GET_USER_PROFILE]);
     },
     ...mutationOptions,
   });

--- a/frontend/src/service/@shared/hooks/queries/user/useUpdate.ts
+++ b/frontend/src/service/@shared/hooks/queries/user/useUpdate.ts
@@ -1,12 +1,12 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 
 import { userAPI } from 'api';
 import { QUERY_KEY } from 'constant';
 import { UseCustomMutationOptions, UpdateProfileResponse } from 'types';
 
-function useUpdateProfile(mutationOptions?: UseCustomMutationOptions<UpdateProfileResponse>) {
-  const queryClient = useQueryClient();
+import queryClient from 'api/config/queryClient';
 
+function useUpdateProfile(mutationOptions?: UseCustomMutationOptions<UpdateProfileResponse>) {
   return useMutation(userAPI.updateProfile, {
     onSuccess: () => {
       queryClient.invalidateQueries([QUERY_KEY.DATA.USER, QUERY_KEY.API.GET_USER_PROFILE]);

--- a/frontend/src/service/review/pages/ReviewAnswerEditorPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewAnswerEditorPage/index.tsx
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { faCircleCheck } from '@fortawesome/free-regular-svg-icons';
-import { useQueryClient } from '@tanstack/react-query';
 
-import { PAGE_LIST, QUERY_KEY } from 'constant';
-import { ErrorResponse, Question, UserProfileResponse } from 'types';
+import { PAGE_LIST } from 'constant';
+import { ErrorResponse, Question } from 'types';
 
 import useSnackbar from 'common/hooks/useSnackbar';
 import useQuestions from 'service/@shared/hooks/useQuestions';
@@ -22,7 +21,6 @@ const EDITOR_MODE = {
 function ReviewAnswerEditorPage() {
   const { reviewFormCode = '', reviewId = '' } = useParams();
   const [searchParams] = useSearchParams();
-  const queryClient = useQueryClient();
 
   const navigate = useNavigate();
   const snackbar = useSnackbar();
@@ -43,15 +41,10 @@ function ReviewAnswerEditorPage() {
     updateAnswer,
   } = useQuestions(questions, setQuestions);
 
-  const { nickname } = queryClient.getQueryData([
-    QUERY_KEY.DATA.AUTH,
-    QUERY_KEY.API.GET_AUTH_MY_PROFILE,
-  ]) as UserProfileResponse;
-
   const [isPrivate, setPrivate] = useState(!!reviewAnswer.info.isPrivate);
   const [focusQuestionIndex, setFocusQuestionIndex] = useState(0);
   const [reviewTitle, setReviewTitle] = useState(
-    reviewId ? reviewAnswer.info.reviewTitle : `${nickname}의 회고`,
+    reviewId ? reviewAnswer.info.reviewTitle : `${authorProfile?.nickname}의 회고`,
   );
 
   const handleFocusAnswer = (index: number) => () => {
@@ -138,7 +131,9 @@ function ReviewAnswerEditorPage() {
 
       <Editor onSubmit={handleSubmit}>
         <Editor.TitleInput
-          placeholder={reviewId ? reviewAnswer.info.reviewTitle : `${nickname}의 회고`}
+          placeholder={
+            reviewId ? reviewAnswer.info.reviewTitle : `${authorProfile?.nickname}의 회고`
+          }
           title={reviewTitle}
           onChange={handleReviewTitleChange}
         />

--- a/frontend/src/service/review/pages/ReviewFormEditorPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewFormEditorPage/index.tsx
@@ -103,7 +103,7 @@ function ReviewFormEditorPage() {
   const handleCancel = () => {
     if (!confirm('회고 생성을 정말 취소하시겠습니까?\n취소 후 복구를 할 수 없습니다.')) return;
 
-    navigate(redirectUri || PAGE_LIST.HOME);
+    navigate(-1);
   };
 
   return (

--- a/frontend/src/service/review/pages/ReviewOverviewPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewOverviewPage/index.tsx
@@ -1,4 +1,3 @@
-import { useContext } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { FILTER, PAGE_LIST, PAGE_OPTION } from 'constant';
@@ -20,7 +19,6 @@ import { Header } from './view/Header';
 import { ListView } from './view/ListView';
 import { SheetView } from './view/SheetView';
 import { updateReviewLike } from 'api/review.api';
-import { UserAgentContext } from 'common/contexts/UserAgent';
 
 /*
   TODO:

--- a/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
@@ -59,7 +59,7 @@ function TemplateDetailPage() {
           description: '답변을 바로 작성하고 팀원과 공유할 수 있습니다.',
         });
 
-        navigate(`${PAGE_LIST.REVIEW}/${reviewFormCode}`, {
+        navigate(`${PAGE_LIST.REVIEW_OVERVIEW}/${reviewFormCode}`, {
           replace: true,
         });
       },


### PR DESCRIPTION
- 회고 답변 작성 라우팅 버그 수정
- 회고 질문지 작성 취소 후 홈으로 리다이렉트 되는 버그 수정
- 템플릿 이용하여 회고 생성 이후 오버뷰로 가도록 버그 수정
- 닉네임 수정시 무효화할 쿼리키 지정
- queryClient import 사용으로 전부 개선(useQueryClient 훅 제거)
- 회고 답변 페이지에서 불필요한 쿼리데이터 가져오는 코드 제거