### PR TITLE
링크 밑 버튼 버그 수정

### DIFF
--- a/frontend/src/service/review/pages/ReviewAnswerEditorPage/index.tsx
+++ b/frontend/src/service/review/pages/ReviewAnswerEditorPage/index.tsx
@@ -103,10 +103,7 @@ function ReviewAnswerEditorPage() {
 
   const handleCancel = () => {
     if (!confirm('회고 작성을 정말 취소하시겠습니까?\n취소 후 복구를 할 수 없습니다.')) return;
-
-    navigate(redirectUri, {
-      replace: true,
-    });
+    navigate(-1);
   };
 
   const handleReviewTitleChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/service/review/pages/ReviewAnswerEditorPage/view/Editor/index.tsx
+++ b/frontend/src/service/review/pages/ReviewAnswerEditorPage/view/Editor/index.tsx
@@ -81,7 +81,7 @@ interface ConfirmButtonsProps {
 const ConfirmButtons = ({ submitDisabled, onSubmit, onCancel }: ConfirmButtonsProps) => {
   return (
     <div className={styles.confirmButtons}>
-      <Button theme="outlined" onClick={onCancel}>
+      <Button type="button" theme="outlined" onClick={onCancel}>
         <FontAwesomeIcon icon={faArrowRightFromBracket} />
         <span>취소하기</span>
       </Button>

--- a/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
+++ b/frontend/src/service/template/pages/TemplateDetailPage/index.tsx
@@ -59,9 +59,7 @@ function TemplateDetailPage() {
           description: '답변을 바로 작성하고 팀원과 공유할 수 있습니다.',
         });
 
-        navigate(`${PAGE_LIST.REVIEW_OVERVIEW}/${reviewFormCode}`, {
-          replace: true,
-        });
+        navigate(`${PAGE_LIST.REVIEW}/${reviewFormCode}`);
       },
       onError: ({ message }) => {
         snackbar.show({


### PR DESCRIPTION
- 회고답변페이지에서 작성 취소 할 때 navigate(-1) 로 뒤로가기로 수정
- 회고 답변 페이지 컨펌 버튼 이벤트 버블링으로 인한 버그 Button 컴포넌트에 type 명시로 해결
- 템플릿에서 바로 회고할 때 회고답변페이지로 이동하도록 링크 수정 