### PR TITLE
캐시 만료 시간 설정 변경

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/config/cache/CacheType.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/config/cache/CacheType.java
@@ -16,7 +16,7 @@ public enum CacheType {
 
     MemberCache("memberCacheStore", 10 * 60, 100),
     TemplateCache("templateCacheStore", 10 * 60, 300),
-    TemplatesCache("templatesCacheStore", 5 * 60, 100);
+    TemplatesCache("templatesCacheStore", 30, 100);
 
     private final String cacheName;
     private final long duration;
@@ -25,7 +25,7 @@ public enum CacheType {
     public CaffeineCache buildCache() {
         return new CaffeineCache(cacheName, Caffeine.newBuilder()
             .recordStats()
-            .expireAfterAccess(duration, TimeUnit.SECONDS)
+            .expireAfterWrite(duration, TimeUnit.SECONDS)
             .maximumSize(maxSize)
             .build());
     }

--- a/backend/reviewduck/src/main/java/com/reviewduck/config/cache/CacheType.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/config/cache/CacheType.java
@@ -16,7 +16,7 @@ public enum CacheType {
 
     MemberCache("memberCacheStore", 10 * 60, 100),
     TemplateCache("templateCacheStore", 10 * 60, 300),
-    TemplatesCache("templatesCacheStore", 30, 100);
+    TemplatesCache("templatesCacheStore", 60, 100);
 
     private final String cacheName;
     private final long duration;

--- a/backend/reviewduck/src/main/java/com/reviewduck/config/cache/CacheType.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/config/cache/CacheType.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 @Getter
 public enum CacheType {
 
-    MemberCache("memberCacheStore", 10 * 60, 100),
+    MemberCache("memberCacheStore", 10 * 60, 150),
     TemplateCache("templateCacheStore", 10 * 60, 300),
     TemplatesCache("templatesCacheStore", 60, 100);
 

--- a/backend/reviewduck/src/main/java/com/reviewduck/template/service/TemplateAggregator.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/service/TemplateAggregator.java
@@ -58,7 +58,7 @@ public class TemplateAggregator {
         return TemplateResponse.of(template, memberId);
     }
 
-    @Cacheable(value = "templatesCacheStore", key = "#page + #size + #sort")
+    //@Cacheable(value = "templatesCacheStore", key = "#page + #size + #sort")
     public TemplatesResponse findAll(int page, int size, String sort, long memberId) {
         Page<Template> templates = templateService.findAll(page, size, sort);
         return TemplatesResponse.of(templates, memberId);

--- a/backend/reviewduck/src/main/java/com/reviewduck/template/service/TemplateAggregator.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/service/TemplateAggregator.java
@@ -3,6 +3,7 @@ package com.reviewduck.template.service;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +33,7 @@ public class TemplateAggregator {
     private final MemberService memberService;
 
     @Transactional
+    @CacheEvict(value = "templatesCacheStore", allEntries = true)
     public TemplateIdResponse save(long memberId, TemplateCreateRequest request) {
         Member member = memberService.findById(memberId);
 
@@ -58,7 +60,7 @@ public class TemplateAggregator {
         return TemplateResponse.of(template, memberId);
     }
 
-    //@Cacheable(value = "templatesCacheStore", key = "#page + #size + #sort")
+    @Cacheable(value = "templatesCacheStore", key = "#page + #size + #sort")
     public TemplatesResponse findAll(int page, int size, String sort, long memberId) {
         Page<Template> templates = templateService.findAll(page, size, sort);
         return TemplatesResponse.of(templates, memberId);
@@ -80,12 +82,16 @@ public class TemplateAggregator {
 
     @Transactional
     @CachePut(value = "templateCacheStore", key = "#templateId")
+    @CacheEvict(value = "templatesCacheStore", allEntries = true)
     public void update(long memberId, long templateId, TemplateUpdateRequest request) {
         templateService.update(memberId, templateId, request);
     }
 
     @Transactional
-    @CacheEvict(value = "templateCacheStore", key = "#templateId")
+    @Caching(evict = {
+        @CacheEvict(value = "templateCacheStore", key = "#templateId"),
+        @CacheEvict(value = "templatesCacheStore", allEntries = true)
+    })
     public void delete(long memberId, long templateId) {
         templateService.deleteById(memberId, templateId);
     }


### PR DESCRIPTION
템플릿 목록 조회와 템플릿 검색 결과에 대한 캐시 유지 시간을 1분으로 단축시키고,
템플릿 수정이나 삭제 작업 수행 시 캐시가 모두 삭제되도록 변경하였습니다. 