### PR TITLE
페이지 서스펜스 state 업데이트시 warning 해결

### DIFF
--- a/frontend/src/common/components/PageSuspense/index.tsx
+++ b/frontend/src/common/components/PageSuspense/index.tsx
@@ -22,7 +22,9 @@ function SuspenseContainer({ children }: ProviderProps) {
   const { fallbackRef } = fallbackContext;
 
   const FallbackComponent = () => {
-    setPageLoaded && setPageLoaded(false);
+    useEffect(() => {
+      setPageLoaded && setPageLoaded(false);
+    }, []);
     return <div className={styles.fallback}>{fallbackRef.current}</div>;
   };
 

--- a/frontend/src/service/pages/UserProfilePage/index.tsx
+++ b/frontend/src/service/pages/UserProfilePage/index.tsx
@@ -24,8 +24,6 @@ import Controller from './view/Controller';
 import styles from './styles.module.scss';
 
 function UserProfilePage() {
-  console.log('test');
-
   const navigate = useNavigate();
   const { socialId = '' } = useParams();
   const [searchParams, setSearchParams] = useSearchParams();


### PR DESCRIPTION
<img width="216" alt="스크린샷 2022-11-09 오후 4 43 26" src="https://user-images.githubusercontent.com/51396282/200768772-1ae838d9-e7f5-4a35-942a-d9ae5ec13ca1.png">

state 업데이트 함수를 useEffect 훅 안으로 이동시켜 실행 순서를 보장하도록 수정했습니다. 