### PR TITLE
변수명 변경 및 ServiceTest Autowired 위치 변경

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/template/controller/TemplateController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/controller/TemplateController.java
@@ -40,7 +40,7 @@ import lombok.AllArgsConstructor;
 @Validated
 public class TemplateController {
 
-    private final TemplateService service;
+    private final TemplateService templateService;
 
     @Operation(summary = "템플릿을 생성한다.")
     @PostMapping
@@ -50,7 +50,7 @@ public class TemplateController {
 
         info("/api/templates", "POST", request.toString());
 
-        return service.save(member.getId(), request);
+        return templateService.save(member.getId(), request);
     }
 
     @Operation(summary = "템플릿을 기반으로 작성된 후 수정된 회고 폼을 생성한다.")
@@ -62,7 +62,7 @@ public class TemplateController {
 
         info("/api/templates/" + templateId + "/review-forms/edited", "POST", request.toString());
 
-        return service.createReviewFormByTemplate(member.getId(), templateId, request);
+        return templateService.createReviewFormByTemplate(member.getId(), templateId, request);
     }
 
     @Operation(summary = "템플릿을 기반으로 회고 폼을 생성한다.")
@@ -73,7 +73,7 @@ public class TemplateController {
 
         info("/api/templates/" + templateId + "/review-forms", "POST", "");
 
-        return service.createReviewFormByTemplate(member.getId(), templateId);
+        return templateService.createReviewFormByTemplate(member.getId(), templateId);
     }
 
     @Operation(summary = "전체 템플릿을 조회한다.")
@@ -86,7 +86,7 @@ public class TemplateController {
 
         info("/api/templates?page=" + page + " size=" + size, "GET", "");
 
-        return service.findAll(page - 1, size, sort, member.getId());
+        return templateService.findAll(page - 1, size, sort, member.getId());
     }
 
     @Operation(summary = "사용자가 생성한 템플릿을 모두 조회한다.")
@@ -99,7 +99,7 @@ public class TemplateController {
 
         info("/api/templates?member=" + socialId + " page=" + page + " size=" + size, "GET", "");
 
-        return service.findAllBySocialId(socialId, page - 1, size, member.getId());
+        return templateService.findAllBySocialId(socialId, page - 1, size, member.getId());
     }
 
     @Operation(summary = "템플릿 검색 결과를 조회한다.")
@@ -112,7 +112,7 @@ public class TemplateController {
 
         info("/api/templates/search?query=" + query + " page=" + page + " size=" + size, "GET", "");
 
-        return service.search(query, page, size, member.getId());
+        return templateService.search(query, page, size, member.getId());
     }
 
     @Operation(summary = "특정 템플릿을 조회한다.")
@@ -122,7 +122,7 @@ public class TemplateController {
 
         info("/api/templates/" + templateId, "GET", "");
 
-        return service.find(templateId, member.getId());
+        return templateService.find(templateId, member.getId());
     }
 
     @Operation(summary = "템플릿을 수정한다.")
@@ -133,7 +133,7 @@ public class TemplateController {
 
         info("/api/templates/" + templateId, "PUT", "");
 
-        service.update(member.getId(), templateId, request);
+        templateService.update(member.getId(), templateId, request);
     }
 
     @Operation(summary = "템플릿을 삭제한다.")
@@ -143,7 +143,7 @@ public class TemplateController {
 
         info("/api/templates/" + templateId, "DELETE", "");
 
-        service.delete(member.getId(), templateId);
+        templateService.delete(member.getId(), templateId);
     }
 
 }

--- a/backend/reviewduck/src/test/java/com/reviewduck/common/service/ServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/common/service/ServiceTest.java
@@ -10,13 +10,6 @@ import org.springframework.test.context.jdbc.Sql;
 
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.repository.MemberRepository;
-import com.reviewduck.member.service.MemberService;
-import com.reviewduck.review.repository.ReviewFormRepository;
-import com.reviewduck.review.repository.ReviewRepository;
-import com.reviewduck.review.service.ReviewFormService;
-import com.reviewduck.review.service.ReviewService;
-import com.reviewduck.template.repository.TemplateRepository;
-import com.reviewduck.template.service.TemplateService;
 
 @SpringBootTest
 @Sql("classpath:truncate.sql")
@@ -27,20 +20,6 @@ public class ServiceTest {
     protected long memberId1;
     protected long memberId2;
 
-    @Autowired
-    protected TemplateService templateService;
-    @Autowired
-    protected ReviewFormRepository reviewFormRepository;
-    @Autowired
-    protected ReviewRepository reviewRepository;
-    @Autowired
-    protected TemplateRepository templateRepository;
-    @Autowired
-    protected ReviewService reviewService;
-    @Autowired
-    protected MemberService memberService;
-    @Autowired
-    protected ReviewFormService reviewFormService;
     @Autowired
     protected MemberRepository memberRepository;
     @Autowired

--- a/backend/reviewduck/src/test/java/com/reviewduck/member/service/MemberServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/member/service/MemberServiceTest.java
@@ -6,12 +6,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.reviewduck.common.service.ServiceTest;
 import com.reviewduck.member.domain.Member;
 import com.reviewduck.member.exception.MemberException;
 
 public class MemberServiceTest extends ServiceTest {
+
+    @Autowired
+    private MemberService memberService;
 
     @Test
     @DisplayName("아이디로 멤버를 조회한다.")

--- a/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/review/service/ReviewFormServiceTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,13 +32,22 @@ import com.reviewduck.review.dto.controller.response.ReviewFormCodeResponse;
 import com.reviewduck.review.dto.controller.response.ReviewFormResponse;
 import com.reviewduck.review.dto.service.QuestionAnswerCreateDto;
 import com.reviewduck.review.dto.service.ReviewFormQuestionCreateDto;
-import com.reviewduck.template.dto.controller.request.TemplateCreateRequest;
-import com.reviewduck.template.dto.controller.request.TemplateQuestionCreateRequest;
+import com.reviewduck.review.repository.ReviewFormRepository;
+import com.reviewduck.review.repository.ReviewRepository;
 
 public class ReviewFormServiceTest extends ServiceTest {
 
     private final String invalidCode = "aaaaaaaa";
     private final ReviewForm mockReviewForm = mock(ReviewForm.class);
+
+    @Autowired
+    private ReviewFormService reviewFormService;
+
+    @Autowired
+    private ReviewFormRepository reviewFormRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
 
     @Nested
     @DisplayName("회고 폼 생성")

--- a/backend/reviewduck/src/test/java/com/reviewduck/template/service/TemplateServiceTest.java
+++ b/backend/reviewduck/src/test/java/com/reviewduck/template/service/TemplateServiceTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import com.reviewduck.auth.exception.AuthorizationException;
 import com.reviewduck.common.exception.NotFoundException;
@@ -33,6 +34,9 @@ public class TemplateServiceTest extends ServiceTest {
     private final List<TemplateQuestionCreateRequest> questions2 = List.of(
         new TemplateQuestionCreateRequest("question3", "description3"),
         new TemplateQuestionCreateRequest("question4", "description4"));
+
+    @Autowired
+    private TemplateService templateService;
 
     @Nested
     @DisplayName("템플릿 생성")


### PR DESCRIPTION
- controller에서 service를 선언할 때, TemplateController에서만 XXXService가 아닌 service라는 필드명을 가지고있었습니다. 이를 templateService로 수정했습니다.
- 기존 test에서는 ServiceTest에서 필요한 필드들을 모두 선언해놓고 이를 상속받아 각 서비스테스트에서 이용했습니다. 이는 Application Context 캐싱에 대한 이해가 부족하여 캐싱되지 않는다고 판단했기 때문이며, 각 테스트에서 사용해야하는 필드가 해당 클래스 내부가 아닌 상위에 존재한다는 것이 유지보수에 좋지 않다고 판단하여 이를 제거했습니다.