### PR TITLE
회고 답변 수정시 불필요한 질문_답변이 자동으로 삭제되도록 변경

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/review/domain/Review.java
@@ -50,7 +50,7 @@ public class Review extends BaseDate {
     @Column(nullable = false)
     private int likes;
 
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "review", fetch = FetchType.LAZY)
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "review", fetch = FetchType.LAZY, orphanRemoval = true)
     @OrderBy("position asc")
     @JsonIgnore
     private final List<QuestionAnswer> questionAnswers = new ArrayList<>();


### PR DESCRIPTION
회고 답변 수정시 QuestionAnswer에 orphanRemoval이 걸려있지 않아 삭제되지 않고 조회하는 에러 상황을 해결했습니다.