### PR TITLE
템플릿 검색 시 페이지 번호 오류 문제 해결

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/template/controller/TemplateController.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/template/controller/TemplateController.java
@@ -112,7 +112,7 @@ public class TemplateController {
 
         info("/api/templates/search?query=" + query + " page=" + page + " size=" + size, "GET", "");
 
-        return templateService.search(query, page, size, member.getId());
+        return templateService.search(query, page - 1, size, member.getId());
     }
 
     @Operation(summary = "특정 템플릿을 조회한다.")


### PR DESCRIPTION
템플릿 조회 시 페이지네이션에서 page -1 이 되어있지 않아 검색 결과가 조회되지 않는 버그를 해결했습니다! 