### PR TITLE
회원정보 조회시 자신의 회원정보로 캐싱되던 버그 해결

### DIFF
--- a/backend/reviewduck/src/main/java/com/reviewduck/member/service/MemberService.java
+++ b/backend/reviewduck/src/main/java/com/reviewduck/member/service/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    @Cacheable(value = "memberCacheStore", key = "#myMemberId")
+    @Cacheable(value = "memberCacheStore", key = "#socialId")
     public MemberResponse findMemberInfo(String socialId, long myMemberId) {
         Member member = findBySocialId(socialId);
         return MemberResponse.of(member, myMemberId);


### PR DESCRIPTION
소셜아이디로 회원정보를 조회하는 경우 캐시 키가 자신의 id로 설정되어있어 항상 자신의 정보만을 반환하고 있었습니다.
이를 socialId로 변경하여 버그를 해결했습니다!